### PR TITLE
KakaoTalkProvider 주입 방식 수정 

### DIFF
--- a/app/src/main/java/com/yapp/attendance/di/KakaoSdkModule.kt
+++ b/app/src/main/java/com/yapp/attendance/di/KakaoSdkModule.kt
@@ -1,0 +1,24 @@
+package com.yapp.attendance.di
+
+import com.yapp.common.util.KakaoSdkProvider
+import com.yapp.data.firebase.FirebaseRemoteConfigProvider
+import com.yapp.domain.common.KakaoSdkProviderInterface
+import com.yapp.domain.firebase.FirebaseRemoteConfig
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class KakaoSdkModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindsKakaoSdkModule(
+        kakaoSdkProvider: KakaoSdkProvider
+    ): KakaoSdkProviderInterface
+
+}

--- a/domain/src/main/java/com/yapp/domain/common/KakaoSdkProviderInterface.kt
+++ b/domain/src/main/java/com/yapp/domain/common/KakaoSdkProviderInterface.kt
@@ -1,0 +1,20 @@
+package com.yapp.domain.common
+
+interface KakaoSdkProviderInterface {
+    fun login(
+        onSuccess: () -> Unit,
+        onFailed: () -> Unit
+    )
+
+    fun logout(
+        onSuccess: () -> Unit,
+        onFailed: () -> Unit,
+    )
+
+    fun getUserAccountId(
+        onSuccess: (Long) -> Unit,
+        onFailed: () -> Unit,
+    )
+
+    fun validateAccessToken(onSuccess: (Long) -> Unit, onFailed: () -> Unit)
+}

--- a/domain/src/main/java/com/yapp/domain/usecases/SetMemberIdUseCase.kt
+++ b/domain/src/main/java/com/yapp/domain/usecases/SetMemberIdUseCase.kt
@@ -1,0 +1,15 @@
+package com.yapp.domain.usecases
+
+import com.yapp.domain.repository.LocalRepository
+import com.yapp.domain.util.BaseUseCase
+import com.yapp.domain.util.TaskResult
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SetMemberIdUseCase @Inject constructor(
+    private val localRepository: LocalRepository,
+) : BaseUseCase<Flow<TaskResult<Unit?>>, Long?>() {
+    override suspend fun invoke(params: Long?): Flow<TaskResult<Unit>> {
+        return localRepository.setMemberId(params!!).toResult()
+    }
+}

--- a/presentation/src/main/java/com/yapp/presentation/ui/AttendanceScreen.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/AttendanceScreen.kt
@@ -8,7 +8,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.yapp.common.theme.Yapp_Orange
-import com.yapp.common.util.KakaoTalkLoginProvider
 import com.yapp.presentation.ui.admin.browse.AdminTotalScore
 import com.yapp.presentation.ui.admin.main.AdminMain
 import com.yapp.presentation.ui.login.Login
@@ -22,7 +21,6 @@ import com.yapp.presentation.ui.splash.Splash
 
 @Composable
 fun AttendanceScreen(
-    kakaoTalkLoginProvider: KakaoTalkLoginProvider,
     navController: NavHostController = rememberNavController(),
 ) {
     NavHost(
@@ -34,7 +32,6 @@ fun AttendanceScreen(
         ) {
             SetStatusBarColorByRoute(it.destination.route)
             Login(
-                kakaoTalkLoginProvider = kakaoTalkLoginProvider,
                 navigateToQRMainScreen = {
                     navController.navigate(AttendanceScreenRoute.SIGNUP_NAME.route) {
                         popUpTo(AttendanceScreenRoute.LOGIN.route) { inclusive = true }

--- a/presentation/src/main/java/com/yapp/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/MainActivity.kt
@@ -1,24 +1,16 @@
 package com.yapp.presentation.ui
 
 import android.os.Bundle
-import android.util.Log
-import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.LocalOverScrollConfiguration
 import androidx.compose.runtime.CompositionLocalProvider
-import com.kakao.sdk.common.util.Utility
 import com.yapp.common.theme.AttendanceTheme
-import com.yapp.common.util.KakaoTalkLoginProvider
-import com.yapp.common.util.KeyboardVisibilityUtils
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-    @Inject
-    lateinit var kakaoTalkLoginProvider: KakaoTalkLoginProvider
 
     @OptIn(ExperimentalFoundationApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -28,9 +20,7 @@ class MainActivity : ComponentActivity() {
                 CompositionLocalProvider(
                     LocalOverScrollConfiguration provides null
                 ) {
-                    AttendanceScreen(
-                        kakaoTalkLoginProvider
-                    )
+                    AttendanceScreen()
                 }
             }
         }

--- a/presentation/src/main/java/com/yapp/presentation/ui/login/Login.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/login/Login.kt
@@ -1,6 +1,5 @@
 package com.yapp.presentation.ui.login
 
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -9,41 +8,34 @@ import androidx.compose.ui.Modifier
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.ConstraintSet
-import androidx.constraintlayout.compose.layoutId
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.airbnb.lottie.compose.*
 import com.yapp.common.R.*
 import com.yapp.common.theme.AttendanceTheme
 import com.yapp.common.theme.AttendanceTypography
-import com.yapp.common.util.KakaoTalkLoginProvider
 import com.yapp.common.yds.YDSButtonLarge
 import com.yapp.common.yds.YDSProgressBar
 import com.yapp.common.yds.YdsButtonState
 import com.yapp.presentation.R
 import com.yapp.presentation.ui.login.LoginContract.*
-import com.yapp.presentation.ui.splash.SplashContract
 import kotlinx.coroutines.flow.collect
 
 @Composable
 fun Login(
-    kakaoTalkLoginProvider: KakaoTalkLoginProvider,
     viewModel: LoginViewModel = hiltViewModel(),
     navigateToQRMainScreen: () -> Unit,
     navigateToSignUpScreen: () -> Unit,
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
-    viewModel.initKakaoLogin(kakaoTalkLoginProvider)
 
     AttendanceTheme {
         LaunchedEffect(key1 = viewModel.effect) {

--- a/presentation/src/main/java/com/yapp/presentation/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/login/LoginViewModel.kt
@@ -1,20 +1,19 @@
 package com.yapp.presentation.ui.login
 
 import com.yapp.common.base.BaseViewModel
-import com.yapp.common.util.KakaoTalkLoginProvider
+import com.yapp.common.util.KakaoSdkProvider
+import com.yapp.domain.common.KakaoSdkProviderInterface
 import com.yapp.presentation.ui.login.LoginContract.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class LoginViewModel @Inject constructor() :
+class LoginViewModel @Inject constructor(
+    private val kakaoSdkProvider: KakaoSdkProviderInterface
+) :
     BaseViewModel<LoginUiState, LoginUiSideEffect, LoginUiEvent>(
         LoginUiState()
     ) {
-    private var kakaoTalkLoginProvider: KakaoTalkLoginProvider? = null
-    fun initKakaoLogin(provider: KakaoTalkLoginProvider) {
-        kakaoTalkLoginProvider = provider
-    }
 
     override fun handleEvent(event: LoginUiEvent) {
         when (event) {
@@ -22,7 +21,7 @@ class LoginViewModel @Inject constructor() :
                 setState {
                     copy(isLoading = true)
                 }
-                kakaoTalkLoginProvider?.login(
+                kakaoSdkProvider.login(
                     onSuccess = {
                         setEffect(
                             LoginUiSideEffect.NavigateToSignUpScreen,

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSettingViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSettingViewModel.kt
@@ -3,24 +3,27 @@ package com.yapp.presentation.ui.member.setting
 import android.util.Log
 import com.kakao.sdk.user.UserApiClient
 import com.yapp.common.base.BaseViewModel
+import com.yapp.domain.common.KakaoSdkProviderInterface
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
-class MemberSettingViewModel @Inject constructor() :
+class MemberSettingViewModel @Inject constructor(
+    private val kakaoSdkProvider: KakaoSdkProviderInterface
+) :
     BaseViewModel<MemberSettingContract.MemberSettingUiState, MemberSettingContract.MemberSettingUiSideEffect, MemberSettingContract.MemberSettingUiEvent>(
         MemberSettingContract.MemberSettingUiState()
     ) {
 
     private fun logout() {
-        // 카카오톡 로그아웃, 카카오 로직을 묶을 필요가 있을 듯
-        UserApiClient.instance.logout { error ->
-            error?.let {
-                // 실패했다는 토스트
-            } ?: run {
+        kakaoSdkProvider.logout(
+            onSuccess = {
                 setEffect(MemberSettingContract.MemberSettingUiSideEffect.NavigateToLoginScreen)
+            },
+            onFailed = {
+                // 실패했다는 토스트
             }
-        }
+        )
 
         // 카카오 로그인 외에, 저장된 모든 정보를 지우는 유즈케이스가 필요함.
     }

--- a/presentation/src/main/java/com/yapp/presentation/ui/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/splash/SplashViewModel.kt
@@ -1,30 +1,32 @@
 package com.yapp.presentation.ui.splash
 
+import androidx.lifecycle.viewModelScope
 import com.kakao.sdk.auth.AuthApiClient
 import com.kakao.sdk.user.UserApiClient
 import com.yapp.common.base.BaseViewModel
+import com.yapp.domain.common.KakaoSdkProviderInterface
+import com.yapp.domain.usecases.SetMemberIdUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
+    private val kakaoSdkProvider: KakaoSdkProviderInterface,
+    private val setMemberIdUseCase: SetMemberIdUseCase
 ) : BaseViewModel<SplashContract.SplashUiState, SplashContract.SplashUiSideEffect, SplashContract.SplashUiEvent>(
     SplashContract.SplashUiState()
 ) {
     init {
-        if (AuthApiClient.instance.hasToken()) {
-            UserApiClient.instance.accessTokenInfo { _, error ->
-                if (error == null) {
-                    // 토큰 유효성 체크 성공(필요 시 토큰 갱신됨)
-                    setState { copy(loginState = SplashContract.LoginState.SUCCESS) }
-
-                } else {
-                    setState { copy(loginState = SplashContract.LoginState.REQUIRED) }
-                }
+        kakaoSdkProvider.validateAccessToken(
+            onSuccess = { userAccountId ->
+                viewModelScope.launch { setMemberIdUseCase(userAccountId) }
+                setState { copy(loginState = SplashContract.LoginState.SUCCESS) }
+            },
+            onFailed = {
+                setState { copy(loginState = SplashContract.LoginState.REQUIRED) }
             }
-        } else {
-            setState { copy(loginState = SplashContract.LoginState.REQUIRED) }
-        }
+        )
     }
 
     override fun setEvent(event: SplashContract.SplashUiEvent) {


### PR DESCRIPTION
**Description**
- interface 로 주입받을 수 있게 개선
- kakao 로직을 공용으로 관리하기 위해 kakaoSdkProvider 로 네이밍 수정 및 관련 로직 통합
- setMemberIdUseCase 를 통해 kakao id 값 저장 

**Check List**

- [ ] CI/CD 통과여부
- [ ] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [ ] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [ ] 연관된 이슈를 PR에 연결해주세요.

