### PR TITLE
fix: Entity(domain)쪽의 모델과 명칭 똑같이 변경

### DIFF
--- a/data/src/main/java/com/yapp/data/model/AttendanceModel.kt
+++ b/data/src/main/java/com/yapp/data/model/AttendanceModel.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class AttendanceModel(
-    @SerialName("session_id")
     val sessionId: Int? = null,
     val type: AttendanceTypeModel? = null
 ) {

--- a/data/src/main/java/com/yapp/data/model/TeamModel.kt
+++ b/data/src/main/java/com/yapp/data/model/TeamModel.kt
@@ -7,9 +7,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class TeamModel(
-    @SerialName("team")
     val type: String? = null,
-    @SerialName("count")
     val number: Int? = null
 ) {
     companion object {


### PR DESCRIPTION
가져올때 / 세팅할때 서로 필드명이 달라 Convert오류가 예상돼서 수정

**Description**
더미 만들면서 domain의 model과 data의 model의 필드명이 서로 달라, set과  get할 때 convert하는 과정에서 오류가 생길것 같아 급하게 수정합니다.



**Screen Shots**

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|             |             |



**Check List**

- [ ] CI/CD 통과여부
- [ ] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [ ] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [ ] 연관된 이슈를 PR에 연결해주세요.

