### PR TITLE
DateUtil 및 관련 UseCase들 정의

### DIFF
--- a/domain/src/main/java/com/yapp/domain/usecases/GetMemberAttendancesUseCase.kt
+++ b/domain/src/main/java/com/yapp/domain/usecases/GetMemberAttendancesUseCase.kt
@@ -4,6 +4,7 @@ import com.yapp.domain.model.AttendanceEntity
 import com.yapp.domain.repository.LocalRepository
 import com.yapp.domain.repository.MemberRepository
 import com.yapp.domain.util.BaseUseCase
+import com.yapp.domain.util.DispatcherProvider
 import com.yapp.domain.util.TaskResult
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapConcat
@@ -13,7 +14,8 @@ import javax.inject.Inject
 class GetMemberAttendancesUseCase @Inject constructor(
     private val memberRepository: MemberRepository,
     private val localRepository: LocalRepository,
-) : BaseUseCase<@JvmSuppressWildcards Flow<TaskResult<List<AttendanceEntity>?>>, Unit>() {
+    private val coroutineDispatcher: DispatcherProvider,
+) : BaseUseCase<@JvmSuppressWildcards Flow<TaskResult<List<AttendanceEntity>?>>, Unit>(coroutineDispatcher) {
 
     override suspend fun invoke(params: Unit?): Flow<TaskResult<List<AttendanceEntity>?>> {
         return localRepository.getMemberId()

--- a/domain/src/main/java/com/yapp/domain/usecases/GetMemberAttendancesUseCase.kt
+++ b/domain/src/main/java/com/yapp/domain/usecases/GetMemberAttendancesUseCase.kt
@@ -1,0 +1,24 @@
+package com.yapp.domain.usecases
+
+import com.yapp.domain.model.AttendanceEntity
+import com.yapp.domain.repository.LocalRepository
+import com.yapp.domain.repository.MemberRepository
+import com.yapp.domain.util.BaseUseCase
+import com.yapp.domain.util.TaskResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class GetMemberAttendancesUseCase @Inject constructor(
+    private val memberRepository: MemberRepository,
+    private val localRepository: LocalRepository,
+) : BaseUseCase<@JvmSuppressWildcards Flow<TaskResult<List<AttendanceEntity>?>>, Unit>() {
+
+    override suspend fun invoke(params: Unit?): Flow<TaskResult<List<AttendanceEntity>?>> {
+        var memberId: Long = -1
+        localRepository.getMemberId().collect { memberId = it ?: -1 }
+
+        return memberRepository.getMember(memberId).map { it?.attendances }.toResult()
+    }
+}

--- a/domain/src/main/java/com/yapp/domain/usecases/GetMemberAttendancesUseCase.kt
+++ b/domain/src/main/java/com/yapp/domain/usecases/GetMemberAttendancesUseCase.kt
@@ -6,7 +6,7 @@ import com.yapp.domain.repository.MemberRepository
 import com.yapp.domain.util.BaseUseCase
 import com.yapp.domain.util.TaskResult
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -16,9 +16,8 @@ class GetMemberAttendancesUseCase @Inject constructor(
 ) : BaseUseCase<@JvmSuppressWildcards Flow<TaskResult<List<AttendanceEntity>?>>, Unit>() {
 
     override suspend fun invoke(params: Unit?): Flow<TaskResult<List<AttendanceEntity>?>> {
-        var memberId: Long = -1
-        localRepository.getMemberId().collect { memberId = it ?: -1 }
-
-        return memberRepository.getMember(memberId).map { it?.attendances }.toResult()
+        return localRepository.getMemberId()
+            .flatMapConcat { memberId -> memberRepository.getMember(memberId ?: -1) }
+            .map { member -> member?.attendances }.toResult()
     }
 }

--- a/domain/src/main/java/com/yapp/domain/usecases/GetMemberScoreUseCase.kt
+++ b/domain/src/main/java/com/yapp/domain/usecases/GetMemberScoreUseCase.kt
@@ -1,16 +1,12 @@
 package com.yapp.domain.usecases
 
 import com.yapp.domain.firebase.FirebaseRemoteConfig
-import com.yapp.domain.model.MemberEntity
 import com.yapp.domain.repository.LocalRepository
 import com.yapp.domain.repository.MemberRepository
 import com.yapp.domain.util.BaseUseCase
 import com.yapp.domain.util.DateUtil
 import com.yapp.domain.util.TaskResult
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 class GetMemberScoreUseCase @Inject constructor(
@@ -20,15 +16,11 @@ class GetMemberScoreUseCase @Inject constructor(
 ) : BaseUseCase<@JvmSuppressWildcards Flow<TaskResult<Int?>>, Unit>() {
 
     override suspend fun invoke(params: Unit?): Flow<TaskResult<Int?>> {
-        var memberId: Long = -1
-        localRepository.getMemberId().collect { memberId = it ?: -1 }
-        var member: MemberEntity? = null
-        memberRepository.getMember(memberId).collect { member = it }
-        val sessions = firebaseRemoteConfig.getSessionList()
-
-        var memberScore = 0
-        sessions.map { list ->
-            list.forEach {
+        return localRepository.getMemberId().flatMapConcat { memberId ->
+            memberRepository.getMember(memberId ?: -1)
+        }.zip(firebaseRemoteConfig.getSessionList()) { member, sessions ->
+            var memberScore = 0
+            sessions.forEach {
                 // 지난 세션의 출석 점수 계산
                 if (DateUtil.isPastSession(it.date)) {
                     memberScore += member?.attendances?.get(it.sessionId)?.type?.point ?: 0
@@ -36,8 +28,8 @@ class GetMemberScoreUseCase @Inject constructor(
                     return@forEach
                 }
             }
-        }
 
-        return flow { emit(memberScore) }.toResult()
+            memberScore
+        }.toResult()
     }
 }

--- a/domain/src/main/java/com/yapp/domain/usecases/GetMemberScoreUseCase.kt
+++ b/domain/src/main/java/com/yapp/domain/usecases/GetMemberScoreUseCase.kt
@@ -1,0 +1,43 @@
+package com.yapp.domain.usecases
+
+import com.yapp.domain.firebase.FirebaseRemoteConfig
+import com.yapp.domain.model.MemberEntity
+import com.yapp.domain.repository.LocalRepository
+import com.yapp.domain.repository.MemberRepository
+import com.yapp.domain.util.BaseUseCase
+import com.yapp.domain.util.DateUtil
+import com.yapp.domain.util.TaskResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class GetMemberScoreUseCase @Inject constructor(
+    private val memberRepository: MemberRepository,
+    private val localRepository: LocalRepository,
+    private val firebaseRemoteConfig: FirebaseRemoteConfig,
+) : BaseUseCase<@JvmSuppressWildcards Flow<TaskResult<Int?>>, Unit>() {
+
+    override suspend fun invoke(params: Unit?): Flow<TaskResult<Int?>> {
+        var memberId: Long = -1
+        localRepository.getMemberId().collect { memberId = it ?: -1 }
+        var member: MemberEntity? = null
+        memberRepository.getMember(memberId).collect { member = it }
+        val sessions = firebaseRemoteConfig.getSessionList()
+
+        var memberScore = 0
+        sessions.map { list ->
+            list.forEach {
+                // 지난 세션의 출석 점수 계산
+                if (DateUtil.isPastSession(it.date)) {
+                    memberScore += member?.attendances?.get(it.sessionId)?.type?.point ?: 0
+                } else {
+                    return@forEach
+                }
+            }
+        }
+
+        return flow { emit(memberScore) }.toResult()
+    }
+}

--- a/domain/src/main/java/com/yapp/domain/usecases/GetMemberScoreUseCase.kt
+++ b/domain/src/main/java/com/yapp/domain/usecases/GetMemberScoreUseCase.kt
@@ -5,6 +5,7 @@ import com.yapp.domain.repository.LocalRepository
 import com.yapp.domain.repository.MemberRepository
 import com.yapp.domain.util.BaseUseCase
 import com.yapp.domain.util.DateUtil
+import com.yapp.domain.util.DispatcherProvider
 import com.yapp.domain.util.TaskResult
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
@@ -13,7 +14,8 @@ class GetMemberScoreUseCase @Inject constructor(
     private val memberRepository: MemberRepository,
     private val localRepository: LocalRepository,
     private val firebaseRemoteConfig: FirebaseRemoteConfig,
-) : BaseUseCase<@JvmSuppressWildcards Flow<TaskResult<Int?>>, Unit>() {
+    private val coroutineDispatcher: DispatcherProvider,
+) : BaseUseCase<@JvmSuppressWildcards Flow<TaskResult<Int?>>, Unit>(coroutineDispatcher) {
 
     override suspend fun invoke(params: Unit?): Flow<TaskResult<Int?>> {
         return localRepository.getMemberId().flatMapConcat { memberId ->

--- a/domain/src/main/java/com/yapp/domain/usecases/GetUpcomingSessionUseCase.kt
+++ b/domain/src/main/java/com/yapp/domain/usecases/GetUpcomingSessionUseCase.kt
@@ -1,0 +1,23 @@
+package com.yapp.domain.usecases
+
+import com.yapp.domain.firebase.FirebaseRemoteConfig
+import com.yapp.domain.model.SessionEntity
+import com.yapp.domain.util.BaseUseCase
+import com.yapp.domain.util.DateUtil
+import com.yapp.domain.util.TaskResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class GetUpcomingSessionUseCase @Inject constructor(
+    private val firebaseRemoteConfig: FirebaseRemoteConfig,
+) : BaseUseCase<@JvmSuppressWildcards Flow<TaskResult<SessionEntity?>>, Unit>() {
+
+    override suspend fun invoke(params: Unit?): Flow<TaskResult<SessionEntity?>> {
+        // 세션 당일 밤 12시까지
+        return firebaseRemoteConfig.getSessionList()
+            .map { list ->
+                list.firstOrNull { !DateUtil.isPastSession(it.date) }
+            }.toResult()
+    }
+}

--- a/domain/src/main/java/com/yapp/domain/usecases/GetUpcomingSessionUseCase.kt
+++ b/domain/src/main/java/com/yapp/domain/usecases/GetUpcomingSessionUseCase.kt
@@ -4,6 +4,7 @@ import com.yapp.domain.firebase.FirebaseRemoteConfig
 import com.yapp.domain.model.SessionEntity
 import com.yapp.domain.util.BaseUseCase
 import com.yapp.domain.util.DateUtil
+import com.yapp.domain.util.DispatcherProvider
 import com.yapp.domain.util.TaskResult
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -11,7 +12,8 @@ import javax.inject.Inject
 
 class GetUpcomingSessionUseCase @Inject constructor(
     private val firebaseRemoteConfig: FirebaseRemoteConfig,
-) : BaseUseCase<@JvmSuppressWildcards Flow<TaskResult<SessionEntity?>>, Unit>() {
+    private val coroutineDispatcher: DispatcherProvider,
+) : BaseUseCase<@JvmSuppressWildcards Flow<TaskResult<SessionEntity?>>, Unit>(coroutineDispatcher) {
 
     override suspend fun invoke(params: Unit?): Flow<TaskResult<SessionEntity?>> {
         // 세션 당일 밤 12시까지

--- a/domain/src/main/java/com/yapp/domain/usecases/GetUpcomingSessionUseCase.kt
+++ b/domain/src/main/java/com/yapp/domain/usecases/GetUpcomingSessionUseCase.kt
@@ -17,7 +17,7 @@ class GetUpcomingSessionUseCase @Inject constructor(
         // 세션 당일 밤 12시까지
         return firebaseRemoteConfig.getSessionList()
             .map { list ->
-                list.firstOrNull { !DateUtil.isPastSession(it.date) }
+                list.firstOrNull { DateUtil.isUpcomingSession(it.date) }
             }.toResult()
     }
 }

--- a/domain/src/main/java/com/yapp/domain/util/DateUtil.kt
+++ b/domain/src/main/java/com/yapp/domain/util/DateUtil.kt
@@ -1,0 +1,17 @@
+package com.yapp.domain.util
+
+import java.text.SimpleDateFormat
+import java.util.*
+
+object DateUtil {
+
+    // 현재 시각이 session 시작 시간에서 몇 분 지났는지 계산
+    // 세션 시작 시간이 지난 경우 양수(+)
+    // 세션 시작이 아직 남은 경우 음수(-)
+    fun getElapsedTime(sessionDateStr: String): Long {
+        val currentDate = System.currentTimeMillis()
+        val sessionDate =
+            SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.KOREA).parse(sessionDateStr).time
+        return (currentDate - sessionDate) / 1000 / 60
+    }
+}

--- a/domain/src/main/java/com/yapp/domain/util/DateUtil.kt
+++ b/domain/src/main/java/com/yapp/domain/util/DateUtil.kt
@@ -22,4 +22,10 @@ object DateUtil {
         val sessionDate = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA).parse(sessionDateStr).time
         return currentDate < sessionDate
     }
+
+    // 지난 세션인지 확인
+    // 세션 시작 시간이 지나면 true
+    fun isPastSession(sessionDateStr: String): Boolean {
+        return getElapsedTime(sessionDateStr) >= 0
+    }
 }

--- a/domain/src/main/java/com/yapp/domain/util/DateUtil.kt
+++ b/domain/src/main/java/com/yapp/domain/util/DateUtil.kt
@@ -14,4 +14,13 @@ object DateUtil {
             SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.KOREA).parse(sessionDateStr).time
         return (currentDate - sessionDate) / 1000 / 60
     }
+
+    // 지난 세션인지 확인
+    // 세션 다음날부터 true
+    fun isPastSession(sessionDateStr: String): Boolean {
+        val currentDate = System.currentTimeMillis()
+        // TODO 지금 당일부터 true인걸로 되어있음
+        val sessionDate = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA).parse(sessionDateStr).time
+        return currentDate > sessionDate
+    }
 }

--- a/domain/src/main/java/com/yapp/domain/util/DateUtil.kt
+++ b/domain/src/main/java/com/yapp/domain/util/DateUtil.kt
@@ -15,12 +15,11 @@ object DateUtil {
         return (currentDate - sessionDate) / 1000 / 60
     }
 
-    // 지난 세션인지 확인
-    // 세션 다음날부터 true
-    fun isPastSession(sessionDateStr: String): Boolean {
+    // 다가오는 세션인지 확인
+    // 세션 날짜가 오늘 이후이면 true
+    fun isUpcomingSession(sessionDateStr: String): Boolean {
         val currentDate = System.currentTimeMillis()
-        // TODO 지금 당일부터 true인걸로 되어있음
         val sessionDate = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA).parse(sessionDateStr).time
-        return currentDate > sessionDate
+        return currentDate < sessionDate
     }
 }


### PR DESCRIPTION
**Description**
- DateUtil 정의
  - `getElapsedTime()`: 세션 시작 후 몇 분이 지났는지
  - `isUpcomingSession()`: 다가오는 세션인지 (시간 상관 없이 날짜만 비교)
  - `isPastSession()`: 지난 세션인지 (세션 시작 시간과 비교)
- 관련 UseCase 정의
  - 멤버 출석 정보 조회
  - 멤버 출석 점수 계산
  - 다가오는 세션 조회

`GetMemberScoreUseCase`에서 이 부분 코드가 좀 지저분해보이는데 개선 가능하면 알려주시면 감사하겠습니다 ㅠ.ㅠ
```kotlin
        var memberId: Long = -1
        localRepository.getMemberId().collect { memberId = it ?: -1 }
        var member: MemberEntity? = null
        memberRepository.getMember(memberId).collect { member = it }
```

**Check List**

- [ ] CI/CD 통과여부
- [ ] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [ ] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [ ] 연관된 이슈를 PR에 연결해주세요.

