### PR TITLE
관리자 메인 화면에서 세션별 출석 관리 화면으로 이동할 수 있도록 구현합니다

### DIFF
--- a/common/src/main/java/com/yapp/common/yds/YDSAppBar.kt
+++ b/common/src/main/java/com/yapp/common/yds/YDSAppBar.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role.Companion.Image
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.yapp.common.R
@@ -62,7 +63,9 @@ fun YDSAppBar(
                 .padding(start = 20.dp, end = 20.dp),
             textAlign = TextAlign.Center,
             style = AttendanceTypography.h3,
-            color = Gray_1200
+            color = Gray_1200,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
 
         Icon(

--- a/presentation/src/main/java/com/yapp/presentation/ui/AttendanceScreen.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/AttendanceScreen.kt
@@ -23,10 +23,10 @@ import androidx.navigation.navArgument
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.yapp.common.theme.Yapp_Orange
 import com.yapp.common.yds.YDSToast
+import com.yapp.presentation.ui.admin.AdminConstants.KEY_SESSION_ID
+import com.yapp.presentation.ui.admin.AdminConstants.KEY_SESSION_TITLE
 import com.yapp.presentation.ui.admin.main.AdminMain
 import com.yapp.presentation.ui.admin.management.AttendanceManagement
-import com.yapp.presentation.ui.admin.management.ManagementViewModel.Companion.KEY_SESSION_ID
-import com.yapp.presentation.ui.admin.management.ManagementViewModel.Companion.KEY_SESSION_TITLE
 import com.yapp.presentation.ui.admin.totalscore.AdminTotalScore
 import com.yapp.presentation.ui.login.Login
 import com.yapp.presentation.ui.member.help.Help

--- a/presentation/src/main/java/com/yapp/presentation/ui/AttendanceScreen.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/AttendanceScreen.kt
@@ -25,6 +25,8 @@ import com.yapp.common.theme.Yapp_Orange
 import com.yapp.common.yds.YDSToast
 import com.yapp.presentation.ui.admin.main.AdminMain
 import com.yapp.presentation.ui.admin.management.AttendanceManagement
+import com.yapp.presentation.ui.admin.management.ManagementViewModel.Companion.KEY_SESSION_ID
+import com.yapp.presentation.ui.admin.management.ManagementViewModel.Companion.KEY_SESSION_TITLE
 import com.yapp.presentation.ui.admin.totalscore.AdminTotalScore
 import com.yapp.presentation.ui.login.Login
 import com.yapp.presentation.ui.member.help.Help
@@ -107,9 +109,21 @@ fun AttendanceScreen(
             route = AttendanceScreenRoute.ADMIN_MAIN.route
         ) {
             SetStatusBarColorByRoute(it.destination.route)
-            AdminMain { upcomingSessionId ->
-                navController.navigate(AttendanceScreenRoute.ADMIN_TOTAL_SCORE.route + "/${upcomingSessionId}")
-            }
+            AdminMain(
+                navigateToAdminTotalScore = { upcomingSessionId ->
+                    navController.navigate(
+                        AttendanceScreenRoute.ADMIN_TOTAL_SCORE.route
+                            .plus("/${upcomingSessionId}")
+                    )
+                },
+                navigateToManagement = { sessionId, sessionTitle ->
+                    navController.navigate(
+                        AttendanceScreenRoute.ADMIN_ATTENDANCE_MANAGEMENT.route
+                            .plus("/${sessionId}")
+                            .plus("/${sessionTitle}")
+                    )
+                }
+            )
         }
 
         composable(
@@ -117,7 +131,7 @@ fun AttendanceScreen(
         ) {
             SetStatusBarColorByRoute(it.destination.route)
             MemberMain(
-                navigateToScreen =  { route ->
+                navigateToScreen = { route ->
                     if (route == AttendanceScreenRoute.QR_AUTH.route) {
                         viewModel.setEvent(MainContract.MainUiEvent.OnClickQrAuthButton)
                     } else {
@@ -137,6 +151,12 @@ fun AttendanceScreen(
 
         composable(
             route = AttendanceScreenRoute.ADMIN_ATTENDANCE_MANAGEMENT.route
+                .plus("/{$KEY_SESSION_ID}")
+                .plus("/{$KEY_SESSION_TITLE}"),
+            arguments = listOf(
+                navArgument(KEY_SESSION_ID) { type = NavType.IntType },
+                navArgument(KEY_SESSION_TITLE) { type = NavType.StringType }
+            )
         ) {
             AttendanceManagement(
                 onBackButtonClicked = { navController.popBackStack() }
@@ -151,15 +171,13 @@ fun AttendanceScreen(
                     navController.popBackStack()
                 },
                 onClickAdminButton = {
-                    // TODO [임시] 원래 Main이 들어와야 함
-                    navController.navigate(AttendanceScreenRoute.ADMIN_ATTENDANCE_MANAGEMENT.route)
-//                    navController.navigate(AttendanceScreenRoute.ADMIN_MAIN.route) {
-//                        popUpTo(AttendanceScreenRoute.MEMBER_SETTING.route) { inclusive = true }
-//                    }
+                    navController.navigate(AttendanceScreenRoute.ADMIN_MAIN.route) {
+                        popUpTo(AttendanceScreenRoute.MEMBER_SETTING.route) { inclusive = true }
+                    }
                 },
                 onClickLogoutButton = {
                     navController.navigate(AttendanceScreenRoute.LOGIN.route) {
-                        // 모든 스택을 다 제거해야함.
+                        // TODO: 모든 스택을 다 제거해야함.
                         popUpTo(AttendanceScreenRoute.MEMBER_SETTING.route)
                     }
                 },
@@ -180,7 +198,7 @@ fun AttendanceScreen(
         composable(
             route = AttendanceScreenRoute.HELP.route
         ) {
-            Help{ navController.popBackStack()}
+            Help { navController.popBackStack() }
         }
 
         composable(
@@ -265,9 +283,9 @@ fun AttendanceScreen(
 
         composable(
             route = AttendanceScreenRoute.ADMIN_TOTAL_SCORE.route
-                .plus("/{$UPCOMING_SESSION_ID_KEY}"),
+                .plus("/{$KEY_UPCOMING_SESSION_ID}"),
             arguments = listOf(
-                navArgument(UPCOMING_SESSION_ID_KEY) { type = NavType.IntType }
+                navArgument(KEY_UPCOMING_SESSION_ID) { type = NavType.IntType }
             )
         ) {
             AdminTotalScore(navigateToPreviousScreen = { navController.popBackStack() })
@@ -328,4 +346,4 @@ private fun SetStatusBarColorByRoute(route: String?) {
     }
 }
 
-const val UPCOMING_SESSION_ID_KEY = "upcomingSessionId"
+const val KEY_UPCOMING_SESSION_ID = "upcomingSessionId"

--- a/presentation/src/main/java/com/yapp/presentation/ui/admin/AdminConstants.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/admin/AdminConstants.kt
@@ -1,0 +1,7 @@
+package com.yapp.presentation.ui.admin
+
+
+object AdminConstants {
+    const val KEY_SESSION_ID = "sessionId"
+    const val KEY_SESSION_TITLE = "sessionTitle"
+}

--- a/presentation/src/main/java/com/yapp/presentation/ui/admin/main/AdminMain.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/admin/main/AdminMain.kt
@@ -76,9 +76,9 @@ fun AdminMain(
                         )
                     )
                 },
-                onSessionItemClicked = { sessionId, sessionTitle ->
+                onSessionClicked = { sessionId, sessionTitle ->
                     viewModel.setEvent(
-                        AdminMainUiEvent.OnSessionItemClicked(sessionId, sessionTitle)
+                        AdminMainUiEvent.OnSessionClicked(sessionId, sessionTitle)
                     )
                 }
             )
@@ -91,7 +91,7 @@ fun AdminMain(
 fun AdminMainScreen(
     uiState: AdminMainUiState,
     onUserScoreCardClicked: () -> Unit,
-    onSessionItemClicked: (Int, String) -> Unit
+    onSessionClicked: (Int, String) -> Unit
 ) {
     LazyColumn(
         modifier = Modifier
@@ -103,7 +103,7 @@ fun AdminMainScreen(
         )
         GraySpacing(Modifier.height(12.dp))
         ManagementTitle()
-        uiState.upcomingSession?.let { UpcomingSession(it) } ?: FinishAllSessions()
+        uiState.upcomingSession?.let { UpcomingSession(it, onSessionClicked) } ?: FinishAllSessions()
         Spacing()
         GraySpacing(
             Modifier
@@ -113,7 +113,7 @@ fun AdminMainScreen(
         ManagementSubTitle()
         Sessions(
             sessions = uiState.sessions,
-            onSessionItemClicked = onSessionItemClicked
+            onSessionItemClicked = onSessionClicked
         )
     }
 }
@@ -198,7 +198,10 @@ fun LazyListScope.GraySpacing(modifier: Modifier) {
     }
 }
 
-fun LazyListScope.UpcomingSession(upcomingSession: Session) {
+fun LazyListScope.UpcomingSession(
+    upcomingSession: Session,
+    onManagementButtonClicked: (Int, String) -> Unit
+) {
     item {
         Column(
             modifier = Modifier.padding(horizontal = 24.dp)
@@ -224,7 +227,7 @@ fun LazyListScope.UpcomingSession(upcomingSession: Session) {
                 YDSButtonSmall(
                     text = stringResource(id = string.admin_main_admin_button),
                     state = if (upcomingSession.type == NeedToAttendType.NEED_ATTENDANCE) YdsButtonState.ENABLED else YdsButtonState.DISABLED,
-                    onClick = {}
+                    onClick = { onManagementButtonClicked(upcomingSession.sessionId, upcomingSession.title) }
                 )
             }
         }

--- a/presentation/src/main/java/com/yapp/presentation/ui/admin/main/AdminMainContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/admin/main/AdminMainContract.kt
@@ -18,9 +18,11 @@ class AdminMainContract {
 
     sealed class AdminMainUiSideEffect : UiSideEffect {
         class NavigateToAdminTotalScore(val upcomingSessionId: Int) : AdminMainUiSideEffect()
+        class NavigateToManagement(val sessionId: Int, val sessionTitle: String) : AdminMainUiSideEffect()
     }
 
     sealed class AdminMainUiEvent : UiEvent {
         class OnUserScoreCardClicked(val upcomingSessionId: Int) : AdminMainUiEvent()
+        class OnSessionItemClicked(val sessionId: Int, val sessionTitle: String) : AdminMainUiEvent()
     }
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/admin/main/AdminMainContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/admin/main/AdminMainContract.kt
@@ -23,6 +23,6 @@ class AdminMainContract {
 
     sealed class AdminMainUiEvent : UiEvent {
         class OnUserScoreCardClicked(val upcomingSessionId: Int) : AdminMainUiEvent()
-        class OnSessionItemClicked(val sessionId: Int, val sessionTitle: String) : AdminMainUiEvent()
+        class OnSessionClicked(val sessionId: Int, val sessionTitle: String) : AdminMainUiEvent()
     }
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/admin/main/AdminMainViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/admin/main/AdminMainViewModel.kt
@@ -29,7 +29,7 @@ class AdminMainViewModel @Inject constructor(
             is AdminMainUiEvent.OnUserScoreCardClicked -> setEffect(
                 AdminMainUiSideEffect.NavigateToAdminTotalScore(event.upcomingSessionId)
             )
-            is AdminMainUiEvent.OnSessionItemClicked -> setEffect(
+            is AdminMainUiEvent.OnSessionClicked -> setEffect(
                 AdminMainUiSideEffect.NavigateToManagement(event.sessionId, event.sessionTitle)
             )
         }

--- a/presentation/src/main/java/com/yapp/presentation/ui/admin/main/AdminMainViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/admin/main/AdminMainViewModel.kt
@@ -27,9 +27,10 @@ class AdminMainViewModel @Inject constructor(
     override suspend fun handleEvent(event: AdminMainUiEvent) {
         when (event) {
             is AdminMainUiEvent.OnUserScoreCardClicked -> setEffect(
-                AdminMainUiSideEffect.NavigateToAdminTotalScore(
-                    event.upcomingSessionId
-                )
+                AdminMainUiSideEffect.NavigateToAdminTotalScore(event.upcomingSessionId)
+            )
+            is AdminMainUiEvent.OnSessionItemClicked -> setEffect(
+                AdminMainUiSideEffect.NavigateToManagement(event.sessionId, event.sessionTitle)
             )
         }
     }

--- a/presentation/src/main/java/com/yapp/presentation/ui/admin/management/Management.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/admin/management/Management.kt
@@ -110,7 +110,7 @@ fun ManagementScreen(
                 YDSAppBar(
                     modifier = Modifier.padding(horizontal = 4.dp),
                     title = uiState.sessionTitle,
-                    onClickBackButton = { onBackButtonClicked?.invoke() }
+                    onClickBackButton = { onBackButtonClicked.invoke() }
                 )
             }
         ) {
@@ -234,6 +234,7 @@ fun TeamHeader(
             .background(Color.White)
             .height(62.dp)
             .fillMaxWidth()
+            .clickable { onExpandClicked(!expanded) }
     ) {
         Text(
             modifier = Modifier

--- a/presentation/src/main/java/com/yapp/presentation/ui/admin/management/ManagementViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/admin/management/ManagementViewModel.kt
@@ -5,12 +5,12 @@ import androidx.lifecycle.viewModelScope
 import com.yapp.common.base.BaseViewModel
 import com.yapp.domain.model.AttendanceEntity
 import com.yapp.domain.usecases.GetAllMemberUseCase
-import com.yapp.domain.usecases.GetSessionListUseCase
 import com.yapp.domain.usecases.SetMemberAttendanceUseCase
 import com.yapp.presentation.model.AttendanceType
 import com.yapp.presentation.model.AttendanceType.Companion.mapToEntity
 import com.yapp.presentation.model.Member.Companion.mapTo
-import com.yapp.presentation.model.Session.Companion.mapTo
+import com.yapp.presentation.ui.admin.AdminConstants.KEY_SESSION_ID
+import com.yapp.presentation.ui.admin.AdminConstants.KEY_SESSION_TITLE
 import com.yapp.presentation.ui.admin.management.ManagementContract.*
 import com.yapp.presentation.ui.admin.management.ManagementContract.ManagementState.*
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -27,9 +27,6 @@ class ManagementViewModel @Inject constructor(
 ) : BaseViewModel<ManagementState, ManagementSideEffect, ManagementEvent>(ManagementState()) {
 
     companion object {
-        const val KEY_SESSION_ID = "sessionId"
-        const val KEY_SESSION_TITLE = "sessionTitle"
-
         const val DEFAULT_SESSION_ID = 1
         const val DEFAULT_SESSION_TITLE = "YAPP"
     }
@@ -67,7 +64,7 @@ class ManagementViewModel @Inject constructor(
                     .groupBy { member -> member.team }
                     .map { (team, members) ->
                         TeamState(
-                            teamName = String.format("${team.type?.displayName} ${team.number}"),
+                            teamName = String.format("${team.type?.displayName} ${team.number}팀"),
                             members = members.map { member ->
                                 MemberState(
                                     id = member.id,

--- a/presentation/src/main/java/com/yapp/presentation/ui/admin/totalscore/AdminTotalScore.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/admin/totalscore/AdminTotalScore.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -80,8 +81,10 @@ fun AdminTotalScoreScreen(
             )
         }
 
-
-        itemsIndexed(uiState.teamItemStates) { _, teamItemState ->
+        itemsIndexed(
+            items = uiState.teamItemStates,
+            key = { _, key -> key.teamName }
+        ) { _, teamItemState ->
             TeamItem(
                 teamItemState = teamItemState
             )
@@ -93,7 +96,7 @@ fun AdminTotalScoreScreen(
 fun TeamItem(
     teamItemState: AdminTotalScoreUiState.TeamItemState
 ) {
-    var isExpanded by remember { mutableStateOf(false) }
+    var isExpanded by rememberSaveable { mutableStateOf(false) }
     val iconResourceId =
         if (isExpanded) R.drawable.icon_chevron_up else R.drawable.icon_chevron_down
 

--- a/presentation/src/main/java/com/yapp/presentation/ui/admin/totalscore/AdminTotalScoreViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/admin/totalscore/AdminTotalScoreViewModel.kt
@@ -1,5 +1,6 @@
 package com.yapp.presentation.ui.admin.totalscore
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.yapp.common.base.BaseViewModel
@@ -8,7 +9,7 @@ import com.yapp.presentation.model.Member
 import com.yapp.presentation.model.Member.Companion.mapTo
 import com.yapp.presentation.model.Team
 import com.yapp.presentation.model.collections.AttendanceList
-import com.yapp.presentation.ui.UPCOMING_SESSION_ID_KEY
+import com.yapp.presentation.ui.KEY_UPCOMING_SESSION_ID
 import com.yapp.presentation.ui.admin.totalscore.AdminTotalScoreContract.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -38,7 +39,7 @@ class AdminTotalScoreViewModel @Inject constructor(
         getAllMemberUseCase().collectWithCallback(
             onSuccess = { memberEntity ->
                 val members = memberEntity.map { it.mapTo() }.groupBy { it.team }
-                val upcomingSessionId = savedStateHandle.get<Int>(UPCOMING_SESSION_ID_KEY)
+                val upcomingSessionId = savedStateHandle.get<Int>(KEY_UPCOMING_SESSION_ID)
                     ?: AttendanceList.DEFAULT_UPCOMING_SESSION_ID
                 val teamItemStates = getTeamItemStates(members, upcomingSessionId)
                 setState {


### PR DESCRIPTION
**Description**
- 관리자 메인 화면에서 다가오는 세션의 관리 버튼을 통해 세션별 점수 관리 화면으로 이동할 수 있도록 수정합니다
  - 세션 아이디, 세션 제목을 함께 넘겨줄 수 있도록 수정합니다
- 관리자 메인 화면에서 출석이 필요한 세션을 클릭했을 때 세션별 점수 관리 화면으로 이동할 수 있도록 수정합니다
  - 세션 아이디, 세션 제목을 함께 넘겨줄 수 있도록 수정합니다


**Screen Shots**

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|<img width="511" alt="스크린샷 2022-04-20 오후 2 48 56" src="https://user-images.githubusercontent.com/42907876/164159271-1844e112-1177-41c5-8ca8-484632779390.png"> | <img width="511" alt="스크린샷 2022-04-20 오후 2 49 41" src="https://user-images.githubusercontent.com/42907876/164159386-a915c68d-0841-48bd-a672-2dc27fbb40d6.png"> |



**Check List**

- [x] CI/CD 통과여부
- [x] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [x] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [x] 연관된 이슈를 PR에 연결해주세요.

