### PR TITLE
refactor: 회원가입 로직이 하나의 UseCase로 모이게끔 수정

### DIFF
--- a/domain/src/main/java/com/yapp/domain/usecases/SignUpMemberUseCase.kt
+++ b/domain/src/main/java/com/yapp/domain/usecases/SignUpMemberUseCase.kt
@@ -1,0 +1,61 @@
+package com.yapp.domain.usecases
+
+import com.yapp.domain.firebase.FirebaseRemoteConfig
+import com.yapp.domain.model.AttendanceEntity
+import com.yapp.domain.model.AttendanceTypeEntity
+import com.yapp.domain.model.MemberEntity
+import com.yapp.domain.model.TeamEntity
+import com.yapp.domain.model.types.NeedToAttendType
+import com.yapp.domain.model.types.PositionTypeEntity
+import com.yapp.domain.repository.LocalRepository
+import com.yapp.domain.repository.MemberRepository
+import com.yapp.domain.util.BaseUseCase
+import com.yapp.domain.util.DispatcherProvider
+import com.yapp.domain.util.TaskResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+
+class SignUpMemberUseCase @Inject constructor(
+    private val firebaseRemoteConfig: FirebaseRemoteConfig,
+    private val localRepository: LocalRepository,
+    private val memberRepository: MemberRepository,
+    dispatcherProvider: DispatcherProvider
+) : BaseUseCase<Flow<TaskResult<Unit>>, SignUpMemberUseCase.Params>(dispatcherProvider) {
+
+    override suspend fun invoke(params: Params?): Flow<TaskResult<Unit>> {
+        return firebaseRemoteConfig.getSessionList().map { sessionList ->
+            return@map sessionList.map { session ->
+                AttendanceEntity(
+                    sessionId = session.sessionId,
+                    type = when (session.type) {
+                        NeedToAttendType.DONT_NEED_ATTENDANCE, NeedToAttendType.DAY_OFF -> AttendanceTypeEntity.Normal
+                        NeedToAttendType.NEED_ATTENDANCE -> AttendanceTypeEntity.Absent
+                    }
+                )
+            }
+        }.flatMapConcat { editedSessionList ->
+            localRepository.getMemberId()
+                .map { memberId ->
+                    MemberEntity(
+                        id = memberId!!,
+                        name = params!!.memberName,
+                        position = params.memberPosition,
+                        team = params.teamEntity,
+                        attendances = editedSessionList
+                    )
+                }
+        }.flatMapConcat { memberEntity ->
+            memberRepository.setMember(memberEntity)
+        }.toResult()
+    }
+
+    class Params(
+        val memberName: String,
+        val memberPosition: PositionTypeEntity,
+        val teamEntity: TeamEntity
+    )
+
+}

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
@@ -1,18 +1,13 @@
 package com.yapp.presentation.ui.member.signup.team
 
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.yapp.common.base.BaseViewModel
-import com.yapp.domain.model.AttendanceEntity
-import com.yapp.domain.model.AttendanceTypeEntity
-import com.yapp.domain.model.MemberEntity
 import com.yapp.domain.model.TeamEntity
-import com.yapp.domain.model.types.NeedToAttendType
 import com.yapp.domain.model.types.PositionTypeEntity
-import com.yapp.domain.usecases.*
+import com.yapp.domain.usecases.GetTeamListUseCase
+import com.yapp.domain.usecases.SignUpMemberUseCase
 import com.yapp.presentation.model.Team.Companion.mapTo
-import com.yapp.presentation.model.type.PositionType
 import com.yapp.presentation.model.type.TeamType
 import com.yapp.presentation.ui.member.signup.team.TeamContract.*
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -21,13 +16,10 @@ import javax.inject.Inject
 
 @HiltViewModel
 class TeamViewModel @Inject constructor(
-    private val getSessionListUseCase: GetSessionListUseCase,
     private val getTeamListUseCase: GetTeamListUseCase,
-    private val setMemberUseCase: SetMemberUseCase,
-    private val getMemberIdUseCase: GetMemberIdUseCase,
+    private val signUpMemberUseCase: SignUpMemberUseCase,
     private val savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<TeamUiState, TeamSideEffect, TeamUiEvent>(TeamUiState()) {
-    private var defaultAttendance: List<AttendanceEntity>? = null
 
     init {
         viewModelScope.launch {
@@ -61,67 +53,40 @@ class TeamViewModel @Inject constructor(
                 setState { copy(selectedTeam = uiState.value.selectedTeam.copy(number = event.teamNum)) }
             }
             is TeamUiEvent.ConfirmTeam -> {
-                viewModelScope.launch {
-                    createDefaultAttendance()
-                }
+                require(savedStateHandle.get<String>("name") != null) { setEffect(TeamSideEffect.ShowToast("회원가입 실패"))}
+                require(savedStateHandle.get<String>("position") != null) { setEffect(TeamSideEffect.ShowToast("회원가입 실패"))}
+
+                signUpMember(
+                    memberName = savedStateHandle.get<String>("name")!!,
+                    memberPosition = PositionTypeEntity.of(savedStateHandle.get<String>("position")!!),
+                    teamEntity = TeamEntity(
+                        type = uiState.value.selectedTeam.type!!.name,
+                        number = uiState.value.selectedTeam.number!!
+                    )
+                )
             }
         }
     }
 
-    private suspend fun setMember() {
-        val memberName = savedStateHandle.get<String>("name")
-        val memberPosition = savedStateHandle.get<String>("position")
-
-        getMemberIdUseCase().collectWithCallback(
-            onSuccess = { memberId ->
-                if ((memberId == null) or (memberName == null) or (memberPosition == null) or (defaultAttendance == null)) {
-                    setEffect(TeamSideEffect.ShowToast("회원가입 실패"))
-                } else {
-                    setMemberToFireBase(memberName!!, memberPosition!!, memberId!!)
-                }
-            },
-            onFailed = { setEffect(TeamSideEffect.ShowToast("회원가입 실패")) }
-        )
-    }
-
-    private suspend fun setMemberToFireBase(
+    private suspend fun signUpMember(
         memberName: String,
-        memberPosition: String,
-        memberId: Long
+        memberPosition: PositionTypeEntity,
+        teamEntity: TeamEntity
     ) {
-
-        setMemberUseCase(
-            MemberEntity(
-                id = memberId,
-                name = memberName,
-                position = PositionTypeEntity.of(memberPosition),
-                team = TeamEntity(
-                    type = uiState.value.selectedTeam.type!!.name,
-                    number = uiState.value.selectedTeam.number!!
-                ),
-                attendances = defaultAttendance!!
+        signUpMemberUseCase(
+            params = SignUpMemberUseCase.Params(
+                memberName = memberName,
+                memberPosition = memberPosition,
+                teamEntity = teamEntity
             )
         ).collectWithCallback(
-            onSuccess = { setEffect(TeamSideEffect.NavigateToMainScreen) },
-            onFailed = { setEffect(TeamSideEffect.ShowToast("회원가입 실패")) }
+            onSuccess = {
+                setEffect(TeamSideEffect.NavigateToMainScreen)
+            },
+            onFailed = {
+                setEffect(TeamSideEffect.ShowToast("회원가입 실패"))
+            }
         )
     }
 
-    private suspend fun createDefaultAttendance() {
-        getSessionListUseCase().collectWithCallback(
-            onSuccess = { sessionList ->
-                 defaultAttendance = sessionList.map { session ->
-                    AttendanceEntity(
-                        sessionId = session.sessionId,
-                        type = when(session.type) {
-                            NeedToAttendType.DONT_NEED_ATTENDANCE, NeedToAttendType.DAY_OFF -> AttendanceTypeEntity.Normal
-                            NeedToAttendType.NEED_ATTENDANCE -> AttendanceTypeEntity.Absent
-                        }
-                    )
-                }
-                setMember()
-            },
-            onFailed = {}
-        )
-    }
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
@@ -53,8 +53,10 @@ class TeamViewModel @Inject constructor(
                 setState { copy(selectedTeam = uiState.value.selectedTeam.copy(number = event.teamNum)) }
             }
             is TeamUiEvent.ConfirmTeam -> {
-                require(savedStateHandle.get<String>("name") != null) { setEffect(TeamSideEffect.ShowToast("회원가입 실패"))}
-                require(savedStateHandle.get<String>("position") != null) { setEffect(TeamSideEffect.ShowToast("회원가입 실패"))}
+                if(savedStateHandle.get<String>("name") == null || savedStateHandle.get<String>("position") == null) {
+                    setEffect(TeamSideEffect.ShowToast("회원가입 실패"))
+                    return
+                }
 
                 signUpMember(
                     memberName = savedStateHandle.get<String>("name")!!,


### PR DESCRIPTION

**Description**
어제 머리가 안돌아가서 못했던것 지금 개선해서 올려봅니다!
SignUp 정상적으로 잘 되는것 확인 했습니다

1. 세션 리스트 수정 (휴얍과 같이 출석이 필요없는 경우 세션기본 타입을 Normal로 수정)
2. 로컬에서 MemberId를 가져옴 (이미 로그인된 KakaoId를 가져오는것) 
3. 이 데이터들을 합쳐 SignUp과정을 진행

**Screen Shots**

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|             |             |



**Check List**

- [ ] CI/CD 통과여부
- [ ] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [ ] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [ ] 연관된 이슈를 PR에 연결해주세요.

