### PR TITLE
로그아웃 / 회원 탈퇴 시 발생하는 문제를 수정합니다

### DIFF
--- a/presentation/src/main/java/com/yapp/presentation/ui/AttendanceScreen.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/AttendanceScreen.kt
@@ -181,21 +181,15 @@ fun AttendanceScreen(
             route = AttendanceScreenRoute.MEMBER_SETTING.route
         ) {
             MemberSetting(
-                onClickBackButton = {
+                navigateToPreviousScreen = {
                     navController.popBackStack()
                 },
-                onClickAdminButton = {
-                    navController.navigate(AttendanceScreenRoute.ADMIN_MAIN.route) {
-                        popUpTo(AttendanceScreenRoute.MEMBER_SETTING.route) { inclusive = true }
-                    }
-                },
-                onClickLogoutButton = {
+                navigateToLogin = {
                     navController.navigate(AttendanceScreenRoute.LOGIN.route) {
-                        // TODO: 모든 스택을 다 제거해야함.
-                        popUpTo(AttendanceScreenRoute.MEMBER_SETTING.route)
+                        popUpTo(0)
                     }
                 },
-                onClickPrivacyPolicyButton = {
+                navigateToPrivacyPolicy = {
                     navController.navigate(AttendanceScreenRoute.PRIVACY_POLICY.route)
                 }
             )

--- a/presentation/src/main/java/com/yapp/presentation/ui/admin/totalscore/AdminTotalScore.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/admin/totalscore/AdminTotalScore.kt
@@ -93,9 +93,7 @@ fun AdminTotalScoreScreen(
 }
 
 @Composable
-fun TeamItem(
-    teamItemState: AdminTotalScoreUiState.TeamItemState
-) {
+fun TeamItem(teamItemState: AdminTotalScoreUiState.TeamItemState) {
     var isExpanded by rememberSaveable { mutableStateOf(false) }
     val iconResourceId =
         if (isExpanded) R.drawable.icon_chevron_up else R.drawable.icon_chevron_down
@@ -156,8 +154,8 @@ fun TeamItem(
                     .wrapContentHeight()
             ) {
                 Divider(modifier = Modifier.padding(horizontal = 24.dp), color = Gray_300)
-                for (i in 0 until teamItemState.teamMembers.size) {
-                    MemberItem(memberWithTotal = teamItemState.teamMembers[i])
+                teamItemState.teamMembers.forEach { teamMember ->
+                    MemberItem(memberWithTotal = teamMember)
                 }
                 Divider(modifier = Modifier.padding(horizontal = 24.dp), color = Gray_300)
             }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSetting.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSetting.kt
@@ -64,7 +64,6 @@ fun MemberSetting(
         ) {
             GroupInfo(uiState.generation)
             Profile(uiState.memberName)
-            //ChangeAdminButton(onClickAdminButton)
             Divide()
             MenuList(viewModel)
         }
@@ -111,17 +110,6 @@ private fun Profile(name: String) {
                 .padding(top = 16.dp),
             textAlign = TextAlign.Center
         )
-    }
-}
-
-@Composable
-private fun ChangeAdminButton(onClickAdminButton: () -> Unit) {
-    YDSButtonMedium(
-        text = "관리자 계정으로 전환하기",
-        state = YdsButtonState.ENABLED,
-        modifier = Modifier.padding(start = 24.dp, end = 24.dp, bottom = 28.dp)
-    ) {
-        onClickAdminButton()
     }
 }
 

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSetting.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSetting.kt
@@ -23,10 +23,9 @@ import kotlinx.coroutines.flow.collect
 @Composable
 fun MemberSetting(
     viewModel: MemberSettingViewModel = hiltViewModel(),
-    onClickBackButton: () -> Unit,
-    onClickAdminButton: () -> Unit,
-    onClickLogoutButton: () -> Unit,
-    onClickPrivacyPolicyButton: () -> Unit,
+    navigateToPreviousScreen: () -> Unit,
+    navigateToLogin: () -> Unit,
+    navigateToPrivacyPolicy: () -> Unit,
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
@@ -36,10 +35,10 @@ fun MemberSetting(
         viewModel.effect.collect { effect ->
             when (effect) {
                 is MemberSettingContract.MemberSettingUiSideEffect.NavigateToLoginScreen -> {
-                    onClickLogoutButton()
+                    navigateToLogin()
                 }
                 is MemberSettingContract.MemberSettingUiSideEffect.NavigateToPrivacyPolicyScreen -> {
-                    onClickPrivacyPolicyButton()
+                    navigateToPrivacyPolicy()
                 }
                 is MemberSettingContract.MemberSettingUiSideEffect.ShowToast -> {
                     Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
@@ -52,7 +51,7 @@ fun MemberSetting(
         topBar = {
             YDSAppBar(
                 title = stringResource(id = string.member_setting_title),
-                onClickBackButton = onClickBackButton
+                onClickBackButton = navigateToPreviousScreen
             )
         },
         modifier = Modifier.fillMaxSize(),

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSetting.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSetting.kt
@@ -1,6 +1,8 @@
 package com.yapp.presentation.ui.member.setting
 
-import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Scaffold
@@ -18,6 +20,7 @@ import com.yapp.common.R
 import com.yapp.common.theme.*
 import com.yapp.common.yds.*
 import com.yapp.presentation.R.*
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 
 @Composable
@@ -27,9 +30,8 @@ fun MemberSetting(
     navigateToLogin: () -> Unit,
     navigateToPrivacyPolicy: () -> Unit,
 ) {
-    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
-    val errorMessage = stringResource(id = string.member_setting_error_message)
+    var toastVisible by remember { mutableStateOf(false) }
 
     LaunchedEffect(key1 = viewModel.effect) {
         viewModel.effect.collect { effect ->
@@ -41,7 +43,9 @@ fun MemberSetting(
                     navigateToPrivacyPolicy()
                 }
                 is MemberSettingContract.MemberSettingUiSideEffect.ShowToast -> {
-                    Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
+                    toastVisible = true
+                    delay(1000L)
+                    toastVisible = false
                 }
             }
         }
@@ -72,6 +76,21 @@ fun MemberSetting(
         YDSProgressBar()
     } else if (uiState.loadState == MemberSettingContract.LoadState.Error) {
         YDSEmptyScreen()
+    }
+
+    AnimatedVisibility(
+        visible = toastVisible,
+        enter = fadeIn(),
+        exit = fadeOut()
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = 110.dp),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            YDSToast(text = stringResource(id = string.member_setting_error_message))
+        }
     }
 }
 

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSetting.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSetting.kt
@@ -132,17 +132,6 @@ private fun Profile(name: String) {
 }
 
 @Composable
-private fun ChangeAdminButton(onClickAdminButton: () -> Unit) {
-    YDSButtonMedium(
-        text = "관리자 계정으로 전환하기",
-        state = YdsButtonState.ENABLED,
-        modifier = Modifier.padding(start = 24.dp, end = 24.dp, bottom = 28.dp)
-    ) {
-        onClickAdminButton()
-    }
-}
-
-@Composable
 private fun Divide() {
     Spacer(
         modifier = Modifier

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSetting.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSetting.kt
@@ -64,7 +64,7 @@ fun MemberSetting(
         ) {
             GroupInfo(uiState.generation)
             Profile(uiState.memberName)
-            ChangeAdminButton(onClickAdminButton)
+            //ChangeAdminButton(onClickAdminButton)
             Divide()
             MenuList(viewModel)
         }
@@ -86,7 +86,8 @@ private fun GroupInfo(generation: Int) {
             .fillMaxWidth()
             .background(Yapp_OrangeAlpha)
             .padding(18.dp),
-        textAlign = TextAlign.Center
+        textAlign = TextAlign.Center,
+        style = AttendanceTypography.body1
     )
 }
 
@@ -104,6 +105,7 @@ private fun Profile(name: String) {
         Text(
             text = stringResource(id = string.member_setting_name, name),
             color = Gray_800,
+            style = AttendanceTypography.body1,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 16.dp),
@@ -168,12 +170,14 @@ private fun MenuList(viewModel: MemberSettingViewModel) {
             Text(
                 text = stringResource(id = string.member_setting_version_info_text),
                 color = Gray_1200,
+                style = AttendanceTypography.subtitle1
             )
             Text(
                 text = versionName,
                 color = Gray_600,
                 modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.End
+                textAlign = TextAlign.End,
+                style = AttendanceTypography.subtitle1
             )
         }
         Row(
@@ -187,6 +191,7 @@ private fun MenuList(viewModel: MemberSettingViewModel) {
             Text(
                 text = stringResource(id = string.member_setting_privacy_policy_text),
                 color = Gray_1200,
+                style = AttendanceTypography.subtitle1
             )
             Image(
                 painter = painterResource(id = R.drawable.icon_chevron_right),
@@ -201,6 +206,7 @@ private fun MenuList(viewModel: MemberSettingViewModel) {
         Text(
             text = stringResource(id = string.member_setting_logout_text),
             color = Gray_400,
+            style = AttendanceTypography.subtitle1,
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable {
@@ -211,6 +217,7 @@ private fun MenuList(viewModel: MemberSettingViewModel) {
         Text(
             text = stringResource(id = string.member_setting_withdraw_text),
             color = Gray_400,
+            style = AttendanceTypography.subtitle1,
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable {

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSettingViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSettingViewModel.kt
@@ -10,7 +10,7 @@ import com.yapp.domain.usecases.GetMemberIdUseCase
 import com.yapp.presentation.model.Config.Companion.mapTo
 import com.yapp.presentation.model.Member.Companion.mapTo
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -32,8 +32,10 @@ class MemberSettingViewModel @Inject constructor(
             getFirestoreMemberUseCase().collectWithCallback(
                 onSuccess = {
                     setState {
-                        copy(loadState = MemberSettingContract.LoadState.Idle,
-                            memberName = it?.mapTo()?.name ?: "")
+                        copy(
+                            loadState = MemberSettingContract.LoadState.Idle,
+                            memberName = it?.mapTo()?.name ?: ""
+                        )
                     }
                 },
                 onFailed = {
@@ -47,8 +49,10 @@ class MemberSettingViewModel @Inject constructor(
             getConfigUseCase().collectWithCallback(
                 onSuccess = {
                     setState {
-                        copy(loadState = MemberSettingContract.LoadState.Idle,
-                            generation = it.mapTo().generation)
+                        copy(
+                            loadState = MemberSettingContract.LoadState.Idle,
+                            generation = it.mapTo().generation
+                        )
                     }
                 },
                 onFailed = {

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -60,7 +60,7 @@
     <string name="member_setting_withdraw_dialog_content_text">탈퇴하면 모든 정보가 사라져요.</string>
     <string name="member_setting_withdraw_dialog_negative_button">취소</string>
     <string name="member_setting_withdraw_dialog_positive_button">탈퇴합니다</string>
-    <string name="member_setting_error_message">에러가 발생했어요! 다시 시도해주세요.</string>
+    <string name="member_setting_error_message">오류가 발생했어요. 다시 시도해주세요.</string>
 
     <string name="member_qr_time_inform_text">까지 출석해 주세요.</string>
     <string name="member_qr_late_inform_text">30분까지는 지각, 그 이후는 결석으로 처리돼요.</string>


### PR DESCRIPTION
**Description**
- 로그아웃 / 회원 탈퇴 후 이동한 로그인 화면에서 뒤로 가기 버튼을 눌렀을 때 이전 화면으로 이동하는 문제를 수정합니다
- 로그아웃 / 회원 탈퇴 실패 시 뜨는 기본 토스트를 YDSToast로 변경합니다
- 관리자 전체 화면에서 회원 정보를 표시할 때 사용하던 for문을 forEach문으로 수정합니다(가독성을 위해 변경)


**Screen Shots**

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|             |             |



**Check List**

- [x] CI/CD 통과여부
- [x] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [x] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [x] 연관된 이슈를 PR에 연결해주세요.

