### PR TITLE
Fix: 카카오 로그인 릴리즈에 따른 셋팅 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ fabric.properties
 !/gradle/wrapper/gradle-wrapper.jar
 
 # End of https://www.toptal.com/developers/gitignore/api/androidstudio,macos
+yapp_attendance_keystore

--- a/common/proguard-rules.pro
+++ b/common/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class com.kakao.sdk.**.model.* { <fields>; }
+-keep class * extends com.google.gson.TypeAdapter


### PR DESCRIPTION
**Description**
- KeyStore를 생성함에 따라 git에 올라가지 않도록 ignore에 추가합니- 다
- common module에 빠져있던 카카오로그인  Proguard Rule을 추가합니다.

**Screen Shots**

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|             |             |



**Check List**

- [ ] CI/CD 통과여부
- [ ] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [ ] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [ ] 연관된 이슈를 PR에 연결해주세요.

