### PR TITLE
fix: 멤버 점수 화면으로 전환되면 자동으로 점수를 새로고침하도록 수정

### DIFF
--- a/presentation/src/main/java/com/yapp/presentation/ui/member/score/MemberScore.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/score/MemberScore.kt
@@ -37,6 +37,7 @@ import com.yapp.presentation.R
 import com.yapp.presentation.model.Attendance
 import com.yapp.presentation.model.AttendanceType
 import com.yapp.presentation.model.Session
+import com.yapp.presentation.ui.member.todaysession.TodaySessionContract
 import com.yapp.presentation.util.attendance.checkSessionAttendance
 import java.text.SimpleDateFormat
 import java.util.*
@@ -70,7 +71,12 @@ fun MemberScore(
         }
 
     }
+
+    LaunchedEffect(key1 = true) {
+        viewModel.setEvent(MemberScoreContract.MemberScoreUiEvent.GetMemberScore())
+    }
 }
+
 
 
 @Composable

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/score/MemberScoreContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/score/MemberScoreContract.kt
@@ -8,7 +8,7 @@ import com.yapp.presentation.model.Session
 
 class MemberScoreContract {
     data class MemberScoreUiState(
-        val loadState: LoadState = LoadState.Idle,
+        val loadState: LoadState = LoadState.Loading,
         val attendanceList: List<Pair<Session, Attendance>> = emptyList(),
         val lastAttendanceList: List<Pair<Session, Attendance>> = emptyList()
     ) : UiState {
@@ -21,5 +21,6 @@ class MemberScoreContract {
     }
 
     sealed class MemberScoreUiEvent : UiEvent {
+        class GetMemberScore() : MemberScoreUiEvent()
     }
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/todaysession/TodaySessionContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/todaysession/TodaySessionContract.kt
@@ -8,7 +8,7 @@ import com.yapp.presentation.model.Session
 
 class TodaySessionContract {
     data class TodaySessionUiState(
-        val loadState: LoadState = LoadState.Idle,
+        val loadState: LoadState = LoadState.Loading,
         val sessionId: Int = 0,
         val attendanceType: AttendanceType = AttendanceType.Absent,
         val todaySession: Session? = null,


### PR DESCRIPTION
**Description**
- 출석체크 이후 멤버 점수화면에 반영된 점수를 표시하려면 로그아웃/종료 후 다시 들어와야 했던 문제를 수정합니다


**Screen Shots**

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|             |             |



**Check List**

- [ ] CI/CD 통과여부
- [ ] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [ ] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [ ] 연관된 이슈를 PR에 연결해주세요.

