### PR TITLE
fix: 출석 테이블 카운팅 기준 수정

### DIFF
--- a/presentation/src/main/java/com/yapp/presentation/ui/member/score/MemberScore.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/score/MemberScore.kt
@@ -1,7 +1,6 @@
 package com.yapp.presentation.ui.member.score
 
 import android.graphics.Paint
-import android.util.Log
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
@@ -14,14 +13,19 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.*
+import androidx.compose.material.Icon
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.*
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -30,14 +34,15 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.res.ResourcesCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.yapp.common.theme.*
-import com.yapp.common.yds.*
+import com.yapp.common.yds.YDSAppBar
+import com.yapp.common.yds.YDSAttendanceList
+import com.yapp.common.yds.YDSEmptyScreen
+import com.yapp.common.yds.YDSProgressBar
 import com.yapp.domain.model.types.NeedToAttendType
-import com.yapp.domain.util.DateUtil
 import com.yapp.presentation.R
 import com.yapp.presentation.model.Attendance
 import com.yapp.presentation.model.AttendanceType
 import com.yapp.presentation.model.Session
-import com.yapp.presentation.ui.member.todaysession.TodaySessionContract
 import com.yapp.presentation.util.attendance.checkSessionAttendance
 import java.text.SimpleDateFormat
 import java.util.*
@@ -229,22 +234,25 @@ fun UserAttendanceTable(lastAttendanceList: List<Pair<Session, Attendance>>) {
         AttendanceCell(
             topText = stringResource(R.string.member_score_attend_text),
             topIconResId = R.drawable.icon_attend,
-            bottomText = lastAttendanceList.filter {
-                ((it.first.type == NeedToAttendType.NEED_ATTENDANCE) and (it.second.attendanceType == AttendanceType.Normal)) or
-                        ((it.first.type == NeedToAttendType.DONT_NEED_ATTENDANCE) and (it.second.attendanceType == AttendanceType.Admit))
-            }.size.toString()
+            bottomText = lastAttendanceList
+                .filter { it.first.type == NeedToAttendType.NEED_ATTENDANCE }
+                .count { (it.second.attendanceType == AttendanceType.Normal) or (it.second.attendanceType == AttendanceType.Admit) }.toString()
         )
 
         AttendanceCell(
             topText = stringResource(R.string.member_score_tardy_text),
             topIconResId = R.drawable.icon_tardy,
-            bottomText = lastAttendanceList.filter { it.second.attendanceType == AttendanceType.Late }.size.toString()
+            bottomText = lastAttendanceList
+                .filter { it.first.type == NeedToAttendType.NEED_ATTENDANCE }
+                .count { it.second.attendanceType == AttendanceType.Late }.toString()
         )
 
         AttendanceCell(
             topText = stringResource(R.string.member_score_absent_text),
             topIconResId = R.drawable.icon_absent,
-            bottomText = lastAttendanceList.filter { it.second.attendanceType == AttendanceType.Absent }.size.toString()
+            bottomText = lastAttendanceList
+                .filter { it.first.type == NeedToAttendType.NEED_ATTENDANCE }
+                .count { it.second.attendanceType == AttendanceType.Absent }.toString()
         )
     }
 }


### PR DESCRIPTION
**Description**

기존 코드는 **출석이 필요하지 않을 때 출석 인정인 경우**(DONT_NEED_ATTENDANCE / 출석 인정)을 세고 있었는데 이를 아래처럼 수정합니다. (테스트 완료)

- 1차로 출석이 필요한세션(NEED_ATTENDANCE)인 Pair들만 걸러냅니다.
- 2차는 아래같이 카운팅합니다.
   - 출석 -> Normal(출석) / Admit(출석 인정)
   - 지각 -> Late(지각)
   - 결석 -> Absent(결석)

```
위의 코드를 수정을 하면서
domain에 존재해야 하는 로직(지금 수정한 코드 포함)들이 presentation 모듈에 존재하는 경우를 종종 봤습니다

당장 MemberScore 화면부터 개선을 하려고 했지만, Data/Domain 모듈이 Flow형태 되어있어 코드가 보기 좋지않고, 수정하기 정말 어려웠습니다.
그래서 **Flow를 빠른 시일내에 전부 걷어내고** 나서 presentation에 존재하는 로직들을 domain에 모이도록 수정하는 작업이
인수인계 전에 꼭 필요하다고 생각합니다.


```


**Screen Shots**

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|             |             |



**Check List**

- [ ] CI/CD 통과여부
- [ ] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [ ] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [ ] 연관된 이슈를 PR에 연결해주세요.

