### PR TITLE
refactor: 회원가입 - 팀 화면 개선

### DIFF
--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/Team.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/Team.kt
@@ -87,7 +87,13 @@ fun Team(
                 Spacer(modifier = Modifier.height(52.dp))
                 TeamNumberOption(
                     uiState = uiState,
-                    onTeamNumberClicked = { viewModel.setEvent(TeamContract.TeamUiEvent.ChooseTeamNumber(it)) }
+                    onTeamNumberClicked = {
+                        viewModel.setEvent(
+                            TeamContract.TeamUiEvent.ChooseTeamNumber(
+                                it
+                            )
+                        )
+                    }
                 )
             }
 
@@ -130,7 +136,6 @@ fun TeamOption(uiState: TeamContract.TeamUiState, onTeamTypeClicked: (String) ->
 
 @Composable
 fun TeamNumberOption(uiState: TeamContract.TeamUiState, onTeamNumberClicked: (Int) -> Unit) {
-    val selectedTeamType = uiState.teams.filter { it.type == uiState.selectedTeamType }
     val density = LocalDensity.current
 
     AnimatedVisibility(
@@ -147,8 +152,8 @@ fun TeamNumberOption(uiState: TeamContract.TeamUiState, onTeamNumberClicked: (In
             )
             Spacer(modifier = Modifier.height(10.dp))
             Row {
-                if (selectedTeamType.isNotEmpty()) {
-                    repeat(selectedTeamType[0].number!!) { teamNum ->
+                if (uiState.numberOfSelectedTeamType != null) {
+                    repeat(uiState.numberOfSelectedTeamType) { teamNum ->
                         YDSChoiceButton(
                             text = stringResource(R.string.member_signup_team_number, teamNum + 1),
                             modifier = Modifier.padding(end = 12.dp, bottom = 12.dp),

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/Team.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/Team.kt
@@ -5,7 +5,14 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.slideInVertically
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -22,7 +29,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.accompanist.insets.systemBarsPadding
 import com.yapp.common.theme.AttendanceTypography
 import com.yapp.common.theme.Gray_1200
-import com.yapp.common.yds.*
+import com.yapp.common.yds.YDSAppBar
+import com.yapp.common.yds.YDSButtonLarge
+import com.yapp.common.yds.YDSChoiceButton
+import com.yapp.common.yds.YdsButtonState
 import com.yapp.presentation.R
 import kotlinx.coroutines.flow.collect
 
@@ -48,7 +58,7 @@ fun Team(
         }
     }
     Scaffold(
-        topBar = { YDSAppBar(onClickBackButton = { onClickBackButton() }) },
+        topBar = { YDSAppBar(onClickBackButton = onClickBackButton) },
         modifier = Modifier
             .fillMaxSize()
             .systemBarsPadding()
@@ -67,20 +77,18 @@ fun Team(
                 Text(
                     text = stringResource(R.string.member_signup_choose_team),
                     style = AttendanceTypography.h1,
-                    color = Gray_1200
+                    color = Gray_1200,
                 )
                 Spacer(modifier = Modifier.height(28.dp))
                 TeamOption(
-                    uiState,
-                    onTeamTypeClicked = { viewModel.setEvent(TeamContract.TeamUiEvent.ChooseTeam(it)) })
+                    uiState = uiState,
+                    onTeamTypeClicked = { viewModel.setEvent(TeamContract.TeamUiEvent.ChooseTeam(it)) }
+                )
                 Spacer(modifier = Modifier.height(52.dp))
                 TeamNumberOption(
-                    uiState,
-                    onTeamNumberClicked = {
-                        viewModel.setEvent(
-                            TeamContract.TeamUiEvent.ChooseTeamNumber(it)
-                        )
-                    })
+                    uiState = uiState,
+                    onTeamNumberClicked = { viewModel.setEvent(TeamContract.TeamUiEvent.ChooseTeamNumber(it)) }
+                )
             }
 
             YDSButtonLarge(
@@ -103,9 +111,9 @@ fun Team(
 @Composable
 fun TeamOption(uiState: TeamContract.TeamUiState, onTeamTypeClicked: (String) -> Unit) {
     val rowNum = 2
-    Column() {
+    Column {
         repeat(uiState.teams.size / rowNum) { row ->
-            Row() {
+            Row {
                 repeat(rowNum) { index ->
                     val team = uiState.teams[rowNum * row + index]
                     YDSChoiceButton(
@@ -124,21 +132,21 @@ fun TeamOption(uiState: TeamContract.TeamUiState, onTeamTypeClicked: (String) ->
 fun TeamNumberOption(uiState: TeamContract.TeamUiState, onTeamNumberClicked: (Int) -> Unit) {
     val selectedTeamType = uiState.teams.filter { it.type == uiState.selectedTeam.type }
     val density = LocalDensity.current
+
     AnimatedVisibility(
         visible = uiState.selectedTeam.type != null,
         enter = slideInVertically { with(density) { -40.dp.roundToPx() } }
                 + expandVertically(expandFrom = Alignment.CenterVertically)
                 + fadeIn(initialAlpha = 0.3f)
     ) {
-        Column(
-        ) {
+        Column {
             Text(
                 text = stringResource(R.string.member_signup_choose_team_number),
                 style = AttendanceTypography.h3,
                 color = Gray_1200
             )
             Spacer(modifier = Modifier.height(10.dp))
-            Row() {
+            Row {
                 if (selectedTeamType.isNotEmpty()) {
                     repeat(selectedTeamType[0].number!!) { teamNum ->
                         YDSChoiceButton(

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/Team.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/Team.kt
@@ -97,9 +97,9 @@ fun Team(
                     .padding(bottom = 40.dp)
                     .height(60.dp)
                     .align(Alignment.BottomCenter),
-                state = if ((uiState.selectedTeam.type != null) and (uiState.selectedTeam.number != null)) YdsButtonState.ENABLED else YdsButtonState.DISABLED,
+                state = if ((uiState.selectedTeamType != null) and (uiState.selectedTeamNumber != null)) YdsButtonState.ENABLED else YdsButtonState.DISABLED,
                 onClick = {
-                    if ((uiState.selectedTeam.type != null) and (uiState.selectedTeam.number != null)) {
+                    if ((uiState.selectedTeamType != null) and (uiState.selectedTeamNumber != null)) {
                         viewModel.setEvent(TeamContract.TeamUiEvent.ConfirmTeam)
                     }
                 },
@@ -119,7 +119,7 @@ fun TeamOption(uiState: TeamContract.TeamUiState, onTeamTypeClicked: (String) ->
                     YDSChoiceButton(
                         text = team.type!!.displayName,
                         modifier = Modifier.padding(end = 12.dp, bottom = 12.dp),
-                        state = if (uiState.selectedTeam.type == team.type) YdsButtonState.ENABLED else YdsButtonState.DISABLED,
+                        state = if (uiState.selectedTeamType == team.type) YdsButtonState.ENABLED else YdsButtonState.DISABLED,
                         onClick = { onTeamTypeClicked(team.type.name) }
                     )
                 }
@@ -130,11 +130,11 @@ fun TeamOption(uiState: TeamContract.TeamUiState, onTeamTypeClicked: (String) ->
 
 @Composable
 fun TeamNumberOption(uiState: TeamContract.TeamUiState, onTeamNumberClicked: (Int) -> Unit) {
-    val selectedTeamType = uiState.teams.filter { it.type == uiState.selectedTeam.type }
+    val selectedTeamType = uiState.teams.filter { it.type == uiState.selectedTeamType }
     val density = LocalDensity.current
 
     AnimatedVisibility(
-        visible = uiState.selectedTeam.type != null,
+        visible = uiState.selectedTeamType != null,
         enter = slideInVertically { with(density) { -40.dp.roundToPx() } }
                 + expandVertically(expandFrom = Alignment.CenterVertically)
                 + fadeIn(initialAlpha = 0.3f)
@@ -152,7 +152,7 @@ fun TeamNumberOption(uiState: TeamContract.TeamUiState, onTeamNumberClicked: (In
                         YDSChoiceButton(
                             text = stringResource(R.string.member_signup_team_number, teamNum + 1),
                             modifier = Modifier.padding(end = 12.dp, bottom = 12.dp),
-                            state = if (uiState.selectedTeam.number == teamNum + 1) YdsButtonState.ENABLED else YdsButtonState.DISABLED,
+                            state = if (uiState.selectedTeamNumber == teamNum + 1) YdsButtonState.ENABLED else YdsButtonState.DISABLED,
                             onClick = { onTeamNumberClicked(teamNum + 1) }
                         )
                     }
@@ -160,5 +160,4 @@ fun TeamNumberOption(uiState: TeamContract.TeamUiState, onTeamNumberClicked: (In
             }
         }
     }
-
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/Team.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/Team.kt
@@ -32,6 +32,8 @@ import com.yapp.common.theme.Gray_1200
 import com.yapp.common.yds.YDSAppBar
 import com.yapp.common.yds.YDSButtonLarge
 import com.yapp.common.yds.YDSChoiceButton
+import com.yapp.common.yds.YDSEmptyScreen
+import com.yapp.common.yds.YDSProgressBar
 import com.yapp.common.yds.YdsButtonState
 import com.yapp.presentation.R
 import kotlinx.coroutines.flow.collect
@@ -63,54 +65,72 @@ fun Team(
             .fillMaxSize()
             .systemBarsPadding()
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 24.dp)
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .align(Alignment.TopStart),
-            ) {
-                Spacer(modifier = Modifier.height(32.dp))
-                Text(
-                    text = stringResource(R.string.member_signup_choose_team),
-                    style = AttendanceTypography.h1,
-                    color = Gray_1200,
-                )
-                Spacer(modifier = Modifier.height(28.dp))
-                TeamOption(
-                    uiState = uiState,
-                    onTeamTypeClicked = { viewModel.setEvent(TeamContract.TeamUiEvent.ChooseTeam(it)) }
-                )
-                Spacer(modifier = Modifier.height(52.dp))
-                TeamNumberOption(
-                    uiState = uiState,
-                    onTeamNumberClicked = {
-                        viewModel.setEvent(
-                            TeamContract.TeamUiEvent.ChooseTeamNumber(
-                                it
-                            )
-                        )
-                    }
-                )
-            }
 
-            YDSButtonLarge(
-                text = stringResource(R.string.member_signup_team_confirm),
-                modifier = Modifier
-                    .padding(bottom = 40.dp)
-                    .height(60.dp)
-                    .align(Alignment.BottomCenter),
-                state = if ((uiState.selectedTeamType != null) and (uiState.selectedTeamNumber != null)) YdsButtonState.ENABLED else YdsButtonState.DISABLED,
-                onClick = {
-                    if ((uiState.selectedTeamType != null) and (uiState.selectedTeamNumber != null)) {
-                        viewModel.setEvent(TeamContract.TeamUiEvent.ConfirmTeam)
-                    }
+        when (uiState.loadState) {
+            TeamContract.TeamUiState.LoadState.Loading -> YDSProgressBar()
+            TeamContract.TeamUiState.LoadState.Error -> YDSEmptyScreen()
+            TeamContract.TeamUiState.LoadState.Idle -> TeamScreen(
+                uiState = uiState,
+                onTeamTypeClicked = { teamType ->
+                    viewModel.setEvent(TeamContract.TeamUiEvent.ChooseTeam(teamType))
                 },
+                onTeamNumberClicked = { teamNum ->
+                    viewModel.setEvent(TeamContract.TeamUiEvent.ChooseTeamNumber(teamNum))
+                },
+                onConfirmClicked = {
+                    viewModel.setEvent(TeamContract.TeamUiEvent.ConfirmTeam)
+                }
             )
         }
+    }
+}
+
+@Composable
+fun TeamScreen(
+    uiState: TeamContract.TeamUiState,
+    onTeamTypeClicked: (String) -> Unit,
+    onTeamNumberClicked: (Int) -> Unit,
+    onConfirmClicked: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.TopStart),
+        ) {
+            Spacer(modifier = Modifier.height(32.dp))
+            Text(
+                text = stringResource(R.string.member_signup_choose_team),
+                style = AttendanceTypography.h1,
+                color = Gray_1200,
+            )
+            Spacer(modifier = Modifier.height(28.dp))
+            TeamOption(
+                uiState = uiState,
+                onTeamTypeClicked = onTeamTypeClicked
+            )
+            Spacer(modifier = Modifier.height(52.dp))
+            TeamNumberOption(
+                uiState = uiState,
+                onTeamNumberClicked = onTeamNumberClicked
+            )
+        }
+
+        YDSButtonLarge(
+            text = stringResource(R.string.member_signup_team_confirm),
+            modifier = Modifier
+                .padding(bottom = 40.dp)
+                .height(60.dp)
+                .align(Alignment.BottomCenter),
+            state = if ((uiState.selectedTeamType != null) and (uiState.selectedTeamNumber != null)) YdsButtonState.ENABLED else YdsButtonState.DISABLED,
+            onClick = {
+                if ((uiState.selectedTeamType != null) and (uiState.selectedTeamNumber != null)) onConfirmClicked()
+            },
+        )
     }
 }
 

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamContract.kt
@@ -8,12 +8,16 @@ import com.yapp.presentation.model.type.TeamType
 
 sealed class TeamContract {
     data class TeamUiState(
-        val isLoading: Boolean = false,
+        val loadState: LoadState = LoadState.Loading,
         val teams: List<Team> = emptyList(),
         val selectedTeamType: TeamType? = null,
         val selectedTeamNumber: Int? = null,
         val numberOfSelectedTeamType: Int? = null,
-    ) : UiState
+    ) : UiState {
+        enum class LoadState {
+            Loading, Idle, Error
+        }
+    }
 
     sealed class TeamSideEffect : UiSideEffect {
         object NavigateToMainScreen : TeamSideEffect()

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamContract.kt
@@ -12,6 +12,7 @@ sealed class TeamContract {
         val teams: List<Team> = emptyList(),
         val selectedTeamType: TeamType? = null,
         val selectedTeamNumber: Int? = null,
+        val numberOfSelectedTeamType: Int? = null,
     ) : UiState
 
     sealed class TeamSideEffect : UiSideEffect {

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamContract.kt
@@ -4,12 +4,14 @@ import com.yapp.common.base.UiEvent
 import com.yapp.common.base.UiSideEffect
 import com.yapp.common.base.UiState
 import com.yapp.presentation.model.Team
+import com.yapp.presentation.model.type.TeamType
 
 sealed class TeamContract {
     data class TeamUiState(
         val isLoading: Boolean = false,
         val teams: List<Team> = emptyList(),
-        val selectedTeam: Team = Team()
+        val selectedTeamType: TeamType? = null,
+        val selectedTeamNumber: Int? = null,
     ) : UiState
 
     sealed class TeamSideEffect : UiSideEffect {

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
@@ -9,7 +9,9 @@ import com.yapp.domain.usecases.GetTeamListUseCase
 import com.yapp.domain.usecases.SignUpMemberUseCase
 import com.yapp.presentation.model.Team.Companion.mapTo
 import com.yapp.presentation.model.type.TeamType
-import com.yapp.presentation.ui.member.signup.team.TeamContract.*
+import com.yapp.presentation.ui.member.signup.team.TeamContract.TeamSideEffect
+import com.yapp.presentation.ui.member.signup.team.TeamContract.TeamUiEvent
+import com.yapp.presentation.ui.member.signup.team.TeamContract.TeamUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -53,7 +55,7 @@ class TeamViewModel @Inject constructor(
                 setState { copy(selectedTeam = uiState.value.selectedTeam.copy(number = event.teamNum)) }
             }
             is TeamUiEvent.ConfirmTeam -> {
-                if(savedStateHandle.get<String>("name") == null || savedStateHandle.get<String>("position") == null) {
+                if (savedStateHandle.get<String>("name") == null || savedStateHandle.get<String>("position") == null) {
                     setEffect(TeamSideEffect.ShowToast("회원가입 실패"))
                     return
                 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
@@ -28,10 +28,16 @@ class TeamViewModel @Inject constructor(
             getTeamListUseCase()
                 .collectWithCallback(
                     onSuccess = { teamEntities ->
-                        setState { copy(teams = teamEntities.map { it.mapTo() }) }
+                        setState {
+                            copy(
+                                loadState = TeamUiState.LoadState.Idle,
+                                teams = teamEntities.map { it.mapTo() })
+                        }
                     },
                     onFailed = {
-                        //에러 핸들링 필요합니다
+                        setState {
+                            copy(loadState = TeamUiState.LoadState.Error)
+                        }
                     }
                 )
         }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
@@ -41,18 +41,10 @@ class TeamViewModel @Inject constructor(
     override suspend fun handleEvent(event: TeamUiEvent) {
         when (event) {
             is TeamUiEvent.ChooseTeam -> {
-                setState {
-                    copy(
-                        selectedTeam = uiState.value.selectedTeam.copy(
-                            type = TeamType.of(
-                                event.teamType
-                            )
-                        )
-                    )
-                }
+                setState { copy(selectedTeamType = TeamType.of(event.teamType)) }
             }
             is TeamUiEvent.ChooseTeamNumber -> {
-                setState { copy(selectedTeam = uiState.value.selectedTeam.copy(number = event.teamNum)) }
+                setState { copy(selectedTeamNumber = event.teamNum) }
             }
             is TeamUiEvent.ConfirmTeam -> {
                 if (savedStateHandle.get<String>("name") == null || savedStateHandle.get<String>("position") == null) {
@@ -64,8 +56,8 @@ class TeamViewModel @Inject constructor(
                     memberName = savedStateHandle.get<String>("name")!!,
                     memberPosition = PositionTypeEntity.of(savedStateHandle.get<String>("position")!!),
                     teamEntity = TeamEntity(
-                        type = uiState.value.selectedTeam.type!!.name,
-                        number = uiState.value.selectedTeam.number!!
+                        type = uiState.value.selectedTeamType!!.name,
+                        number = uiState.value.selectedTeamNumber!!
                     )
                 )
             }
@@ -92,5 +84,4 @@ class TeamViewModel @Inject constructor(
             }
         )
     }
-
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
@@ -41,7 +41,14 @@ class TeamViewModel @Inject constructor(
     override suspend fun handleEvent(event: TeamUiEvent) {
         when (event) {
             is TeamUiEvent.ChooseTeam -> {
-                setState { copy(selectedTeamType = TeamType.of(event.teamType)) }
+                val selectedTeamType = TeamType.of(event.teamType)
+
+                setState {
+                    copy(
+                        selectedTeamType = selectedTeamType,
+                        numberOfSelectedTeamType = uiState.value.teams.find { it.type == selectedTeamType }?.number
+                    )
+                }
             }
             is TeamUiEvent.ChooseTeamNumber -> {
                 setState { copy(selectedTeamNumber = event.teamNum) }


### PR DESCRIPTION
**Description**

- 선택된 팀 상태 관리를 객체 단위가 아닌 타입 단위로 관리하도록 분리하였습니다.
   - `selectedTeamType: Team? = null`
   ->  `val selectedTeamType: TeamType? = null`
        `val selectedTeamNumber: Int? = null`


- 선택된 팀의 팀 개수의 상태를 뷰가 아닌 뷰모델에서 관리하도록 수정하였습니다.
  -> `val numberOfSelectedTeamType: Int? = null,`


- 다른 화면의 코드에 맞춰 `LoadState` 를 추가하였습니다.
   - Q. 어떤 화면은 `isLoading` 으로 로딩 상태를 관리하던데 왜 이렇게 분리된건지 궁금합니당


**Screen Shots**

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|             |             |



**Check List**

- [ ] CI/CD 통과여부
- [ ] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [ ] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [ ] 연관된 이슈를 PR에 연결해주세요.

