### PR TITLE
[Refactor] 회원 가입 단계 중 이름 입력 코드를 개선합니다

### DIFF
--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/Name.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/Name.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.flow.collectLatest
 fun Name(
     viewModel: NameViewModel = hiltViewModel(),
     onClickBackBtn: () -> Unit,
-    onClickNextBtn: (String) -> Unit,
+    onClickNextBtn: (String) -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsState()
     var isKeyboardOpened by remember { mutableStateOf(false) }
@@ -174,7 +174,7 @@ fun NextButton(
     isKeyboardOpened: Boolean,
     modifier: Modifier,
     onClickNextBtn: () -> Unit,
-    keyboardVisibilityUtils: KeyboardVisibilityUtils,
+    keyboardVisibilityUtils: KeyboardVisibilityUtils
 ) {
     Box(
         modifier = modifier,
@@ -206,7 +206,7 @@ fun NextButton(
 fun OnKeyboardNextButton(
     enabled: Boolean,
     onClickNextBtn: () -> Unit,
-    keyboardVisibilityUtils: KeyboardVisibilityUtils,
+    keyboardVisibilityUtils: KeyboardVisibilityUtils
 ) {
     Button(
         enabled = enabled,

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/Name.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/Name.kt
@@ -51,7 +51,7 @@ fun Name(
     }
 
     Scaffold(
-        topBar = { YDSAppBar(onClickBackButton = { showDialog = !showDialog }) },
+        topBar = { YDSAppBar(onClickBackButton = { showDialog = true }) },
         modifier = Modifier
             .fillMaxSize()
             .statusBarsPadding()
@@ -64,8 +64,8 @@ fun Name(
                 negativeButtonText = stringResource(id = R.string.name_cancel_dialog_no),
                 positiveButtonText = stringResource(id = R.string.name_cancel_dialog_cancel),
                 onClickPositiveButton = { onBackButtonClick() },
-                onClickNegativeButton = { showDialog = !showDialog },
-                onDismiss = { showDialog = !showDialog }
+                onClickNegativeButton = { showDialog = false },
+                onDismiss = { showDialog = false }
             )
         }
 

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/Name.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/Name.kt
@@ -1,6 +1,7 @@
 package com.yapp.presentation.ui.member.signup.name
 
 import android.app.Activity
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -93,6 +94,10 @@ fun Name(
                 keyboardVisibilityUtils = keyboardVisibilityUtils
             )
         }
+    }
+
+    BackHandler {
+        showDialog = true
     }
 
     LaunchedEffect(key1 = viewModel.effect) {

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/Name.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/Name.kt
@@ -10,21 +10,22 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.google.accompanist.insets.*
+import com.google.accompanist.insets.navigationBarsWithImePadding
+import com.google.accompanist.insets.statusBarsPadding
 import com.yapp.common.theme.*
-import com.yapp.common.theme.Gray_800
 import com.yapp.common.util.KeyboardVisibilityUtils
 import com.yapp.common.yds.YDSAppBar
 import com.yapp.common.yds.YDSButtonLarge
 import com.yapp.common.yds.YDSPopupDialog
 import com.yapp.common.yds.YdsButtonState
 import com.yapp.presentation.R
-
+import com.yapp.presentation.ui.member.signup.name.NameContract.NameUiEvent.OnBackButtonClick
+import com.yapp.presentation.ui.member.signup.name.NameContract.NameUiEvent.OnNextButtonClick
+import kotlinx.coroutines.flow.collectLatest
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -39,7 +40,15 @@ fun Name(
     val keyboardVisibilityUtils = KeyboardVisibilityUtils(
         window = (LocalContext.current as Activity).window,
         onShowKeyboard = { isKeyboardOpened = true },
-        onHideKeyboard = { isKeyboardOpened = false })
+        onHideKeyboard = { isKeyboardOpened = false }
+    )
+
+    val onBackButtonClick by remember { mutableStateOf({ viewModel.setEvent(OnBackButtonClick) }) }
+    val onNextButtonClick: (String) -> Unit by remember {
+        mutableStateOf({
+            viewModel.setEvent(OnNextButtonClick(it))
+        })
+    }
 
     Scaffold(
         topBar = { YDSAppBar(onClickBackButton = { showDialog = !showDialog }) },
@@ -54,7 +63,7 @@ fun Name(
                 content = stringResource(id = R.string.name_cancel_dialog_subtitle),
                 negativeButtonText = stringResource(id = R.string.name_cancel_dialog_no),
                 positiveButtonText = stringResource(id = R.string.name_cancel_dialog_cancel),
-                onClickPositiveButton = { onClickBackBtn() },
+                onClickPositiveButton = { onBackButtonClick() },
                 onClickNegativeButton = { showDialog = !showDialog },
                 onDismiss = { showDialog = !showDialog }
             )
@@ -75,23 +84,34 @@ fun Name(
                     onInputName = { viewModel.setEvent(NameContract.NameUiEvent.InputName(it)) }
                 )
             }
+
             NextButton(
                 name = uiState.name,
                 isKeyboardOpened = isKeyboardOpened,
-                modifier = Modifier
-                    .align(Alignment.BottomCenter),
-                onClickNextBtn = onClickNextBtn,
-                keyboardVisibilityUtils= keyboardVisibilityUtils
-
+                modifier = Modifier.align(Alignment.BottomCenter),
+                onClickNextBtn = { onNextButtonClick(it) },
+                keyboardVisibilityUtils = keyboardVisibilityUtils
             )
+        }
+    }
+
+    LaunchedEffect(key1 = viewModel.effect) {
+        viewModel.effect.collectLatest { effect ->
+            when (effect) {
+                is NameContract.NameSideEffect.NavigateToPreviousScreen -> {
+                    onClickBackBtn()
+                }
+                is NameContract.NameSideEffect.NavigateToNextScreen -> {
+                    onClickNextBtn(effect.name)
+                }
+            }
         }
     }
 }
 
 @Composable
 fun Title() {
-    Column() {
-
+    Column {
         Spacer(modifier = Modifier.height(32.dp))
         Text(
             text = stringResource(id = R.string.name_title),

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/Name.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/Name.kt
@@ -24,8 +24,7 @@ import com.yapp.common.yds.YDSButtonLarge
 import com.yapp.common.yds.YDSPopupDialog
 import com.yapp.common.yds.YdsButtonState
 import com.yapp.presentation.R
-import com.yapp.presentation.ui.member.signup.name.NameContract.NameUiEvent.OnBackButtonClick
-import com.yapp.presentation.ui.member.signup.name.NameContract.NameUiEvent.OnNextButtonClick
+import com.yapp.presentation.ui.member.signup.name.NameContract.NameUiEvent.*
 import kotlinx.coroutines.flow.collectLatest
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -46,9 +45,10 @@ fun Name(
 
     val onBackButtonClick by remember { mutableStateOf({ viewModel.setEvent(OnBackButtonClick) }) }
     val onNextButtonClick: (String) -> Unit by remember {
-        mutableStateOf({
-            viewModel.setEvent(OnNextButtonClick(it))
-        })
+        mutableStateOf({ viewModel.setEvent(OnNextButtonClick(it)) })
+    }
+    val onInputNameChange: (String) -> Unit by remember {
+        mutableStateOf({ viewModel.setEvent(InputName(it)) })
     }
 
     Scaffold(
@@ -82,7 +82,7 @@ fun Name(
                 Title()
                 InputName(
                     name = uiState.name,
-                    onInputName = { viewModel.setEvent(NameContract.NameUiEvent.InputName(it)) }
+                    onInputName = { onInputNameChange(it) }
                 )
             }
 

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/Name.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/Name.kt
@@ -33,10 +33,9 @@ import kotlinx.coroutines.flow.collectLatest
 fun Name(
     viewModel: NameViewModel = hiltViewModel(),
     onClickBackBtn: () -> Unit,
-    onClickNextBtn: (String) -> Unit
+    onClickNextBtn: (String) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    var showDialog by remember { mutableStateOf(false) }
     var isKeyboardOpened by remember { mutableStateOf(false) }
     val keyboardVisibilityUtils = KeyboardVisibilityUtils(
         window = (LocalContext.current as Activity).window,
@@ -44,30 +43,36 @@ fun Name(
         onHideKeyboard = { isKeyboardOpened = false }
     )
 
-    val onBackButtonClick by remember { mutableStateOf({ viewModel.setEvent(OnBackButtonClick) }) }
+    val onCancelButtonClick by remember { mutableStateOf({ viewModel.setEvent(OnCancelButtonClick) }) }
     val onNextButtonClick: () -> Unit by remember {
         mutableStateOf({ viewModel.setEvent(OnNextButtonClick) })
     }
     val onInputNameChange: (String) -> Unit by remember {
         mutableStateOf({ viewModel.setEvent(InputName(it)) })
     }
+    val onBackButtonClick: () -> Unit by remember {
+        mutableStateOf({ viewModel.setEvent(OnBackButtonClick) })
+    }
+    val onDismissDialogButtonClick: () -> Unit by remember {
+        mutableStateOf({ viewModel.setEvent(OnDismissDialogButtonClick) })
+    }
 
     Scaffold(
-        topBar = { YDSAppBar(onClickBackButton = { showDialog = true }) },
+        topBar = { YDSAppBar(onClickBackButton = { onBackButtonClick() }) },
         modifier = Modifier
             .fillMaxSize()
             .statusBarsPadding()
             .navigationBarsWithImePadding()
     ) {
-        if (showDialog) {
+        if (uiState.showDialog) {
             YDSPopupDialog(
                 title = stringResource(id = R.string.name_cancel_dialog_title),
                 content = stringResource(id = R.string.name_cancel_dialog_subtitle),
                 negativeButtonText = stringResource(id = R.string.name_cancel_dialog_no),
                 positiveButtonText = stringResource(id = R.string.name_cancel_dialog_cancel),
-                onClickPositiveButton = { onBackButtonClick() },
-                onClickNegativeButton = { showDialog = false },
-                onDismiss = { showDialog = false }
+                onClickPositiveButton = { onCancelButtonClick() },
+                onClickNegativeButton = { onDismissDialogButtonClick() },
+                onDismiss = { onDismissDialogButtonClick() }
             )
         }
 
@@ -98,7 +103,7 @@ fun Name(
     }
 
     BackHandler {
-        showDialog = true
+        onBackButtonClick()
     }
 
     LaunchedEffect(key1 = viewModel.effect) {
@@ -169,7 +174,7 @@ fun NextButton(
     isKeyboardOpened: Boolean,
     modifier: Modifier,
     onClickNextBtn: () -> Unit,
-    keyboardVisibilityUtils: KeyboardVisibilityUtils
+    keyboardVisibilityUtils: KeyboardVisibilityUtils,
 ) {
     Box(
         modifier = modifier,
@@ -201,7 +206,7 @@ fun NextButton(
 fun OnKeyboardNextButton(
     enabled: Boolean,
     onClickNextBtn: () -> Unit,
-    keyboardVisibilityUtils: KeyboardVisibilityUtils
+    keyboardVisibilityUtils: KeyboardVisibilityUtils,
 ) {
     Button(
         enabled = enabled,

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/NameContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/NameContract.kt
@@ -6,8 +6,9 @@ import com.yapp.common.base.UiState
 
 class NameContract {
     data class NameUiState(
+        val showDialog: Boolean = false,
         val isLoading: Boolean = false,
-        val name: String = "",
+        val name: String = ""
     ) : UiState
 
     sealed class NameSideEffect : UiSideEffect {
@@ -17,7 +18,9 @@ class NameContract {
 
     sealed class NameUiEvent : UiEvent {
         data class InputName(val name: String) : NameUiEvent()
-        object OnBackButtonClick : NameUiEvent()
+        object OnCancelButtonClick : NameUiEvent()
         object OnNextButtonClick : NameUiEvent()
+        object OnBackButtonClick : NameUiEvent()
+        object OnDismissDialogButtonClick : NameUiEvent()
     }
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/NameContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/NameContract.kt
@@ -18,6 +18,6 @@ class NameContract {
     sealed class NameUiEvent : UiEvent {
         data class InputName(val name: String) : NameUiEvent()
         object OnBackButtonClick : NameUiEvent()
-        data class OnNextButtonClick(val name: String) : NameUiEvent()
+        object OnNextButtonClick : NameUiEvent()
     }
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/NameContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/NameContract.kt
@@ -7,11 +7,17 @@ import com.yapp.common.base.UiState
 class NameContract {
     data class NameUiState(
         val isLoading: Boolean = false,
-        val name: String = ""
+        val name: String = "",
     ) : UiState
 
-    sealed class NameSideEffect : UiSideEffect {}
+    sealed class NameSideEffect : UiSideEffect {
+        object NavigateToPreviousScreen : NameSideEffect()
+        data class NavigateToNextScreen(val name: String) : NameSideEffect()
+    }
+
     sealed class NameUiEvent : UiEvent {
-        data class InputName(val name:String) : NameUiEvent()
+        data class InputName(val name: String) : NameUiEvent()
+        object OnBackButtonClick : NameUiEvent()
+        data class OnNextButtonClick(val name: String) : NameUiEvent()
     }
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/NameViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/NameViewModel.kt
@@ -16,11 +16,17 @@ class NameViewModel @Inject constructor() :
             is NameContract.NameUiEvent.InputName -> {
                 setState { copy(name = event.name) }
             }
-            is NameContract.NameUiEvent.OnBackButtonClick -> {
+            is NameContract.NameUiEvent.OnCancelButtonClick -> {
                 setEffect(NavigateToPreviousScreen)
             }
             is NameContract.NameUiEvent.OnNextButtonClick -> {
                 setEffect(NavigateToNextScreen(uiState.value.name))
+            }
+            is NameContract.NameUiEvent.OnBackButtonClick -> {
+                setState { copy(showDialog = true) }
+            }
+            is NameContract.NameUiEvent.OnDismissDialogButtonClick -> {
+                setState { copy(showDialog = false) }
             }
         }
     }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/NameViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/NameViewModel.kt
@@ -1,6 +1,8 @@
 package com.yapp.presentation.ui.member.signup.name
 
 import com.yapp.common.base.BaseViewModel
+import com.yapp.presentation.ui.member.signup.name.NameContract.NameSideEffect.NavigateToNextScreen
+import com.yapp.presentation.ui.member.signup.name.NameContract.NameSideEffect.NavigateToPreviousScreen
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -14,7 +16,12 @@ class NameViewModel @Inject constructor() :
             is NameContract.NameUiEvent.InputName -> {
                 setState { copy(name = event.name) }
             }
+            is NameContract.NameUiEvent.OnBackButtonClick -> {
+                setEffect(NavigateToPreviousScreen)
+            }
+            is NameContract.NameUiEvent.OnNextButtonClick -> {
+                setEffect(NavigateToNextScreen(event.name))
+            }
         }
     }
-
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/NameViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/name/NameViewModel.kt
@@ -20,7 +20,7 @@ class NameViewModel @Inject constructor() :
                 setEffect(NavigateToPreviousScreen)
             }
             is NameContract.NameUiEvent.OnNextButtonClick -> {
-                setEffect(NavigateToNextScreen(event.name))
+                setEffect(NavigateToNextScreen(uiState.value.name))
             }
         }
     }


### PR DESCRIPTION
**Description**
- 이벤트 처리 시 뷰모델에서 이벤트를 발생시키고 발생한 사이드 이펙트를 통해서 변경되도록 수정
- not 기호(!)를 통해 `showDialog` state 값을 변경하던 코드를 명시적으로 관리할 수 있도록 수정
  - `showDialog = !showDialog` -> `showDialog = true` or `showDialog = false`
- topBar의 뒤로가기 버튼 클릭 시 다이얼로그를 띄워 취소 여부를 확인하지만, 시스템 백 버튼 클릭 시에는 다이얼로그 없이 앱이 종료되는 문제 수정


**Screen Shots**

| Screen Shot | Screen Shot |
| ----------- | ----------- |
| <img width="511" alt="회원가입 이름 입력 화면 스크린샷" src="https://user-images.githubusercontent.com/42907876/206916983-d32ff08d-d07a-41b6-b28e-2f0942e856a2.png"> |             |



**Check List**

- [x] CI/CD 통과여부
- [x] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [x] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [ ] 연관된 이슈를 PR에 연결해주세요.

