### PR TITLE
fix: YDS 컬러 팔레트 재정의

### DIFF
--- a/common/src/main/java/com/yapp/common/theme/Color.kt
+++ b/common/src/main/java/com/yapp/common/theme/Color.kt
@@ -1,28 +1,153 @@
 package com.yapp.common.theme
 
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 
 
-val Yapp_Orange         = Color(0XFFFA6027)
-val Yapp_OrangeAlpha    = Color(0X1AFA6027)
-val Yapp_OrangePressed  = Color(0XFFFF7744)
-val Yapp_Yellow         = Color(0XFFFFD74B)
-val Yapp_Gradient       = Brush.linearGradient(
-                                colors  = listOf(Yapp_Orange, Yapp_Yellow),
-                                start   = Offset(150F, 40F),
-                                end     = Offset(450F, 40F))
+// Light Colors
+val Light_Yapp_Orange = Color(0XFFFA6027)
+val Light_Yapp_OrangeAlpha = Color(0X1AFA6027)
+val Light_Yapp_OrangePressed = Color(0XFFFF7744)
+val Light_Yapp_Yellow = Color(0XFFFFD74B)
 
-val Etc_Green       = Color(0XFF27AE60)
-val Etc_Yellow      = Color(0XFFFFCE1F)
-val Etc_Yellow_Font = Color(0XFFFFBB0D)
-val Etc_Red         = Color(0XFFEE5120)
+val Light_Etc_Green = Color(0XFF27AE60)
+val Light_Etc_Yellow = Color(0XFFFFCE1F)
+val Light_Etc_Yellow_Font = Color(0XFFFFBB0D)
+val Light_Etc_Red = Color(0XFFEE5120)
 
-val Gray_1200   = Color(0XFF313439)
-val Gray_1000   = Color(0XFF42454A)
-val Gray_800    = Color(0XFF69707B)
-val Gray_600    = Color(0XFF9BA3AE)
-val Gray_400    = Color(0XFFCCD2DA)
-val Gray_300    = Color(0XFFE8EAED)
-val Gray_200    = Color(0XFFF3F5F8)
+val Light_Gray_1200 = Color(0XFF313439)
+val Light_Gray_1000 = Color(0XFF42454A)
+val Light_Gray_800 = Color(0XFF69707B)
+val Light_Gray_600 = Color(0XFF9BA3AE)
+val Light_Gray_400 = Color(0XFFCCD2DA)
+val Light_Gray_300 = Color(0XFFE8EAED)
+val Light_Gray_200 = Color(0XFFF3F5F8)
+
+val Light_Background = Color(0XFFFFFFFF)
+val Light_Background_Base = Color(0XFFF3F5F8)
+val Light_Background_Elevated = Color(0XFFFFFFFF)
+
+val Light_Pressed_Light = Color(0XFFFFFFFF)
+val Light_Pressed_Dark = Color(0XFF98A3AE)
+
+// Dark Colors
+val Dark_Yapp_Orange = Color(0XFFFC7948)
+val Dark_Yapp_OrangeAlpha = Color(0X1AFC7948)
+val Dark_Yapp_OrangePressed = Color(0XFFEF8D64)
+val Dark_Yapp_Yellow = Color(0XFFFFD74B)
+
+val Dark_Etc_Green = Color(0XFF3DBB72)
+val Dark_Etc_Yellow = Color(0XFFFFCE1F)
+val Dark_Etc_Yellow_Font = Color(0XFFFFCE1F)
+val Dark_Etc_Red = Color(0XFFEB6D45)
+
+val Dark_Gray_1200 = Color(0XFFF7F9FB)
+val Dark_Gray_1000 = Color(0XFFE5ECF3)
+val Dark_Gray_800 = Color(0XFFCBD1DC)
+val Dark_Gray_600 = Color(0XFF636877)
+val Dark_Gray_400 = Color(0XFF383944)
+val Dark_Gray_300 = Color(0XFF282A31)
+val Dark_Gray_200 = Color(0XFF202127)
+
+val Dark_Background = Color(0XFF16171D)
+val Dark_Background_Base = Color(0XFF09090B)
+val Dark_Background_Elevated = Color(0XFF282A31)
+
+val Dark_Pressed_Light = Color(0XFF141414)
+val Dark_Pressed_Dark = Color(0XFF141414)
+
+// Brush (Gradient)
+val Yapp_Gradient = Brush.linearGradient(
+    colors = listOf(Light_Yapp_Orange, Light_Yapp_Yellow),
+    start = Offset(150F, 40F),
+    end = Offset(450F, 40F)
+)
+
+@Immutable
+data class SemanticBackgroundColors(
+    val backgroundBase: Color,
+    val background: Color,
+    val backgroundElevated: Color
+)
+
+@Immutable
+data class SemanticPressedColors(
+    val pressLight: Color,
+    val pressDark: Color
+)
+
+@Immutable
+data class YDSColors(
+    val backgroundColors: SemanticBackgroundColors,
+    val pressedColors: SemanticPressedColors,
+    val grayScale: GrayScale,
+    val mainColors: MainColors,
+    val etcColors: EtcColors
+)
+
+@Immutable
+data class GrayScale(
+    val Gray200: Color,
+    val Gray300: Color,
+    val Gray400: Color,
+    val Gray600: Color,
+    val Gray800: Color,
+    val Gray1000: Color,
+    val Gray1200: Color,
+)
+
+@Immutable
+data class MainColors(
+    val YappOrange: Color,
+    val YappOrangeAlpha: Color,
+    val YappOrangePressed: Color,
+    val YappYellow: Color,
+    val YappGradient: Brush
+)
+
+@Immutable
+data class EtcColors(
+    val EtcGreen: Color,
+    val EtcYellow: Color,
+    val EtcYellowFont: Color,
+    val EtcRed: Color,
+)
+
+val LocalYDSColors = staticCompositionLocalOf {
+    YDSColors(
+        backgroundColors = SemanticBackgroundColors(
+            background = Color.Unspecified,
+            backgroundBase = Color.Unspecified,
+            backgroundElevated = Color.Unspecified,
+        ),
+        pressedColors = SemanticPressedColors(
+            pressLight = Color.Unspecified,
+            pressDark = Color.Unspecified
+        ),
+        grayScale = GrayScale(
+            Gray200 = Color.Unspecified,
+            Gray300 = Color.Unspecified,
+            Gray400 = Color.Unspecified,
+            Gray600 = Color.Unspecified,
+            Gray800 = Color.Unspecified,
+            Gray1000 = Color.Unspecified,
+            Gray1200 = Color.Unspecified
+        ),
+        mainColors = MainColors(
+            YappOrange = Color.Unspecified,
+            YappOrangeAlpha = Color.Unspecified,
+            YappOrangePressed = Color.Unspecified,
+            YappYellow = Color.Unspecified,
+            YappGradient = Brush.linearGradient(colors = emptyList())
+        ),
+        etcColors = EtcColors(
+            EtcGreen = Color.Unspecified,
+            EtcYellow = Color.Unspecified,
+            EtcYellowFont = Color.Unspecified,
+            EtcRed = Color.Unspecified
+        )
+    )
+}

--- a/common/src/main/java/com/yapp/common/theme/Theme.kt
+++ b/common/src/main/java/com/yapp/common/theme/Theme.kt
@@ -2,36 +2,105 @@ package com.yapp.common.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.darkColors
-import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
+import androidx.compose.runtime.CompositionLocalProvider
 
-private val ColorPalette = lightColors(
-    primary = Yapp_Orange,
-    background = Color.White,
-    onBackground = Color.Black,
-    surface = Color.White,
-    onSurface = Color.Black
-
-    /* Other default colors to override
-    background = Color.White,
-    surface = Color.White,
-    onPrimary = Color.White,
-    onSecondary = Color.Black,
-    onBackground = Color.Black,
-    onSurface = Color.Black,
-    */
-)
 
 @Composable
 fun AttendanceTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable() () -> Unit) {
-    val colors = ColorPalette
+    val colors = if (darkTheme) {
+        provideDarkThemeColors()
+    } else {
+        provideLightThemeColors()
+    }
 
-    MaterialTheme(
-        colors = colors,
-        typography = AttendanceTypography,
-        shapes = Shapes,
-        content = content
+    CompositionLocalProvider(
+        LocalYDSColors provides colors
+    ) {
+        MaterialTheme(
+            typography = AttendanceTypography,
+            shapes = Shapes,
+            content = content
+        )
+    }
+}
+
+object AttendanceTheme {
+    val colors: YDSColors
+        @Composable
+        get() = LocalYDSColors.current
+}
+
+private fun provideLightThemeColors(): YDSColors {
+    return YDSColors(
+        backgroundColors = SemanticBackgroundColors(
+            background = Light_Background,
+            backgroundBase = Light_Background_Base,
+            backgroundElevated = Light_Background_Elevated,
+        ),
+        pressedColors = SemanticPressedColors(
+            pressLight = Light_Pressed_Light,
+            pressDark = Light_Pressed_Dark
+        ),
+        grayScale = GrayScale(
+            Gray200 = Light_Gray_200,
+            Gray300 = Light_Gray_300,
+            Gray400 = Light_Gray_400,
+            Gray600 = Light_Gray_600,
+            Gray800 = Light_Gray_800,
+            Gray1000 = Light_Gray_1000,
+            Gray1200 = Light_Gray_1200
+        ),
+        mainColors = MainColors(
+            YappOrange = Light_Yapp_Orange,
+            YappOrangeAlpha = Light_Yapp_OrangeAlpha,
+            YappOrangePressed = Light_Yapp_OrangePressed,
+            YappYellow = Light_Yapp_Yellow,
+            YappGradient = Yapp_Gradient
+        ),
+        etcColors = EtcColors(
+            EtcGreen = Light_Etc_Green,
+            EtcYellow = Light_Etc_Yellow,
+            EtcYellowFont = Light_Etc_Yellow_Font,
+            EtcRed = Light_Etc_Red
+        )
     )
 }
+
+private fun provideDarkThemeColors(): YDSColors {
+    return YDSColors(
+        backgroundColors = SemanticBackgroundColors(
+            background = Dark_Background,
+            backgroundBase = Dark_Background_Base,
+            backgroundElevated = Dark_Background_Elevated,
+        ),
+        pressedColors = SemanticPressedColors(
+            pressLight = Dark_Pressed_Light,
+            pressDark = Dark_Pressed_Dark
+        ),
+        grayScale = GrayScale(
+            Gray200 = Dark_Gray_200,
+            Gray300 = Dark_Gray_300,
+            Gray400 = Dark_Gray_400,
+            Gray600 = Dark_Gray_600,
+            Gray800 = Dark_Gray_800,
+            Gray1000 = Dark_Gray_1000,
+            Gray1200 = Dark_Gray_1200
+        ),
+        mainColors = MainColors(
+            YappOrange = Dark_Yapp_Orange,
+            YappOrangeAlpha = Dark_Yapp_OrangeAlpha,
+            YappOrangePressed = Dark_Yapp_OrangePressed,
+            YappYellow = Dark_Yapp_Yellow,
+            YappGradient = Yapp_Gradient
+        ),
+        etcColors = EtcColors(
+            EtcGreen = Dark_Etc_Green,
+            EtcYellow = Dark_Etc_Yellow,
+            EtcYellowFont = Dark_Etc_Yellow_Font,
+            EtcRed = Dark_Etc_Red
+        )
+    )
+}
+
+


### PR DESCRIPTION
- 다크모드 추가를 위해 컬러팔레트를 재정의 합니다
- MaterialTheme에서 컬러팔레트만 확장하도록 합니다.

**Description**



**Screen Shots**

| Screen Shot | Screen Shot |
| ----------- | ----------- |
     
![스크린샷 2023-02-10 오후 10 13 34](https://user-images.githubusercontent.com/53253298/218235049-95b7232d-0833-4769-bf8c-705bc79dce58.png)  ![스크린샷 2023-02-10 오후 10 13 55](https://user-images.githubusercontent.com/53253298/218235061-7f0bfa68-cfab-4621-b87d-e926ef7cc7ad.png)
     



**Check List**

- [ ] CI/CD 통과여부
- [ ] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [ ] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [ ] 연관된 이슈를 PR에 연결해주세요.

