### PR TITLE
fix: 개인정보 처리방침 화면 앱바 색상 수정

### DIFF
--- a/presentation/src/main/java/com/yapp/presentation/ui/member/privacyPolicy/PrivacyPolicyScreen.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/privacyPolicy/PrivacyPolicyScreen.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.Scaffold
@@ -13,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import com.google.accompanist.insets.systemBarsPadding
+import com.yapp.common.theme.AttendanceTheme
 import com.yapp.common.yds.YDSAppBar
 
 
@@ -23,7 +25,13 @@ fun PrivacyPolicyScreen(
     val url = remember { "https://yapprecruit.notion.site/8b561d1b0fa449bba4db395f53a559f3" }
 
     Scaffold(
-        topBar = { YDSAppBar(onClickBackButton = { onClickBackButton() }, title = "개인정보 처리방침") },
+        topBar = {
+            YDSAppBar(
+                modifier = Modifier.background(AttendanceTheme.colors.backgroundColors.background),
+                onClickBackButton = { onClickBackButton() },
+                title = "개인정보 처리방침"
+            )
+        },
         modifier = Modifier
             .fillMaxSize()
             .systemBarsPadding()


### PR DESCRIPTION
**Description**

- 개인정보 처리방침 화면의 앱바가 다크모드일 때 적절한 색상으로 보여지도록 수정하였습니다.

**Screen Shots**

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|    ![Screenshot_1679224693](https://user-images.githubusercontent.com/85336456/226172450-af2e759c-da66-4c2a-95df-89fd2d78d856.png)         |             |



**Check List**

- [ ] CI/CD 통과여부
- [ ] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [ ] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [ ] 연관된 이슈를 PR에 연결해주세요.

