### PR TITLE
온보딩에서 팀 선택 스킵이 가능하도록 변경

### DIFF
--- a/domain/src/main/java/com/yapp/domain/model/Team.kt
+++ b/domain/src/main/java/com/yapp/domain/model/Team.kt
@@ -5,5 +5,13 @@ import com.yapp.domain.model.types.TeamType
 
 data class Team(
     val type: TeamType,
-    val number: Int
-)
+    val number: Int,
+) {
+    override fun toString(): String {
+        return "${type.value} $number"
+    }
+
+    companion object {
+        fun empty() = Team(TeamType.NONE, 0)
+    }
+}

--- a/domain/src/main/java/com/yapp/domain/model/types/TeamType.kt
+++ b/domain/src/main/java/com/yapp/domain/model/types/TeamType.kt
@@ -2,6 +2,7 @@ package com.yapp.domain.model.types
 
 
 enum class TeamType(val value: String) {
+    NONE("None"),
     ANDROID("Android"),
     IOS("iOS"),
     WEB("Web"),
@@ -11,6 +12,7 @@ enum class TeamType(val value: String) {
     companion object {
         fun from(rawValue: String): TeamType {
             return when(rawValue) {
+                "NONE" -> NONE
                 "ANDROID" -> ANDROID
                 "IOS" -> IOS
                 "WEB" -> WEB

--- a/domain/src/main/java/com/yapp/domain/model/types/TeamType.kt
+++ b/domain/src/main/java/com/yapp/domain/model/types/TeamType.kt
@@ -2,7 +2,6 @@ package com.yapp.domain.model.types
 
 
 enum class TeamType(val value: String) {
-    NONE("None"),
     ANDROID("Android"),
     IOS("iOS"),
     WEB("Web"),

--- a/domain/src/main/java/com/yapp/domain/usecases/SignUpMemberUseCase.kt
+++ b/domain/src/main/java/com/yapp/domain/usecases/SignUpMemberUseCase.kt
@@ -26,7 +26,11 @@ class SignUpMemberUseCase @Inject constructor(
             val sessionList = remoteConfigRepository.getSessionList().getOrThrow()
             val editedSessionList = createAttendanceEntities(sessionList)
 
-            val memberEntity = createMember(memberId = currentMemberId, params = params, attendanceEntities = editedSessionList)
+            val memberEntity = createMember(
+                memberId = currentMemberId,
+                params = params,
+                attendanceEntities = editedSessionList,
+            )
 
             memberRepository.setMember(memberEntity)
         }
@@ -54,7 +58,7 @@ class SignUpMemberUseCase @Inject constructor(
             id = memberId,
             name = params.memberName,
             position = params.memberPosition,
-            team = params.team,
+            team = Team.empty(),
             attendances = AttendanceList.from(attendanceEntities)
         )
     }
@@ -62,12 +66,9 @@ class SignUpMemberUseCase @Inject constructor(
     /**
      * @param memberName 회원가입 이름입력 화면에서 입력된 Member 이름
      * @param memberPosition 회원가입 포지션/팀 화면의 선택된 Member 포지션
-     * @param team: 회원가입 포지션/팀 화면의 선택된 Member Team
      * */
     class Params(
         val memberName: String,
         val memberPosition: PositionType,
-        val team: Team,
     )
-
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/AttendanceScreen.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/AttendanceScreen.kt
@@ -59,6 +59,7 @@ fun AttendanceScreen(
                 is MainContract.MainUiSideEffect.NavigateToQRScreen -> {
                     navController.navigate(BottomNavigationItem.QR_AUTH.route)
                 }
+
                 is MainContract.MainUiSideEffect.ShowToast -> {
                     qrToastVisible = !qrToastVisible
                     delay(1000L)
@@ -195,7 +196,12 @@ fun AttendanceScreen(
                 },
                 navigateToPrivacyPolicy = {
                     navController.navigate(AttendanceScreenRoute.PRIVACY_POLICY.route)
-                }
+                },
+                navigateToSelectTeamScreen = {
+                    navController.navigate(AttendanceScreenRoute.SIGNUP_TEAM.route) {
+                        popUpTo(AttendanceScreenRoute.MEMBER_SETTING.route) { inclusive = true }
+                    }
+                },
             )
         }
 
@@ -234,9 +240,11 @@ fun AttendanceScreen(
         ) {
             SetStatusBarColorByRoute(it.destination.route)
             Name(
-                onClickBackBtn = { navController.navigate(AttendanceScreenRoute.LOGIN.route) {
-                    popUpTo(AttendanceScreenRoute.SIGNUP_NAME.route) { inclusive = true }
-                } },
+                onClickBackBtn = {
+                    navController.navigate(AttendanceScreenRoute.LOGIN.route) {
+                        popUpTo(AttendanceScreenRoute.SIGNUP_NAME.route) { inclusive = true }
+                    }
+                },
                 onClickNextBtn = { userName -> navController.navigate(AttendanceScreenRoute.SIGNUP_POSITION.route + "/${userName}") })
         }
 
@@ -250,30 +258,24 @@ fun AttendanceScreen(
             SetStatusBarColorByRoute(it.destination.route)
             Position(
                 onClickBackButton = { navController.popBackStack() },
-                navigateToTeamScreen = { userName, userPosition ->
-                    navController.navigate(
-                        AttendanceScreenRoute.SIGNUP_TEAM.route.plus("/${userName}")
-                            .plus("/${userPosition}")
-                    )
+                navigateToMainScreen = {
+                    navController.navigate(AttendanceScreenRoute.MEMBER_MAIN.route) {
+                        popUpTo(AttendanceScreenRoute.SIGNUP_NAME.route) { inclusive = true }
+                    }
                 }
             )
         }
 
 
         composable(
-            route = AttendanceScreenRoute.SIGNUP_TEAM.route
-                .plus("/{name}")
-                .plus("/{position}"),
-            arguments = listOf(
-                navArgument("name") { type = NavType.StringType },
-                navArgument("position") { type = NavType.StringType })
+            route = AttendanceScreenRoute.SIGNUP_TEAM.route,
         ) {
             SetStatusBarColorByRoute(it.destination.route)
             Team(
                 onClickBackButton = { navController.popBackStack() },
-                navigateToMainScreen = {
-                    navController.navigate(AttendanceScreenRoute.MEMBER_MAIN.route) {
-                        popUpTo(AttendanceScreenRoute.SIGNUP_NAME.route) { inclusive = true }
+                navigateToSettingScreen = {
+                    navController.navigate(AttendanceScreenRoute.MEMBER_SETTING.route) {
+                        popUpTo(AttendanceScreenRoute.SIGNUP_TEAM.route) { inclusive = true }
                     }
                 })
         }
@@ -341,12 +343,14 @@ fun SetStatusBarColorByRoute(route: String?) {
                     color = yappOrange,
                 )
             }
+
             BottomNavigationItem.SESSION.route -> {
                 systemUiController.setStatusBarColor(
                     color = backgroundBase,
                     darkIcons = shouldShowLightIcon
                 )
             }
+
             else -> {
                 systemUiController.setStatusBarColor(
                     color = Color.Transparent,

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSetting.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSetting.kt
@@ -22,11 +22,15 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.accompanist.insets.systemBarsPadding
 import com.yapp.common.R
+import com.yapp.common.flow.collectAsStateWithLifecycle
 import com.yapp.common.theme.*
 import com.yapp.common.yds.*
+import com.yapp.domain.model.Team
+import com.yapp.domain.model.types.TeamType
 import com.yapp.presentation.R.*
-import com.yapp.presentation.util.permission.PermissionBundle
 import kotlinx.coroutines.delay
+
+private fun Team.hasTeam() = type != TeamType.NONE
 
 @Composable
 fun MemberSetting(
@@ -34,8 +38,9 @@ fun MemberSetting(
     navigateToPreviousScreen: () -> Unit,
     navigateToLogin: () -> Unit,
     navigateToPrivacyPolicy: () -> Unit,
+    navigateToSelectTeamScreen: () -> Unit,
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var toastVisible by remember { mutableStateOf(false) }
 
     LaunchedEffect(key1 = viewModel.effect) {
@@ -51,6 +56,10 @@ fun MemberSetting(
                     toastVisible = true
                     delay(1000L)
                     toastVisible = false
+                }
+
+                MemberSettingContract.MemberSettingUiSideEffect.NavigateToSelectTeamScreen -> {
+                    navigateToSelectTeamScreen()
                 }
             }
         }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSetting.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSetting.kt
@@ -77,7 +77,15 @@ fun MemberSetting(
                 .verticalScroll(rememberScrollState())
         ) {
             GroupInfo(uiState.generation)
-            Profile(uiState.memberName)
+            Profile(
+                name = uiState.memberName,
+                position = uiState.memberPosition,
+                team = uiState.memberTeam,
+            )
+            SelectTeam(
+                hasTeam = uiState.memberTeam.hasTeam(),
+                onClick = { viewModel.setEvent(MemberSettingContract.MemberSettingUiEvent.OnSelectTeamButtonClicked) }
+            )
             Divide()
             MenuList(viewModel)
         }
@@ -120,7 +128,16 @@ private fun GroupInfo(generation: Int) {
 }
 
 @Composable
-private fun Profile(name: String) {
+private fun Profile(
+    name: String,
+    position: String,
+    team: Team,
+) {
+    val subInfo = if (team.hasTeam()) {
+        "$position · $team"
+    } else {
+        position
+    }
     Column(
         modifier = Modifier.padding(horizontal = 24.dp, vertical = 28.dp)
     ) {
@@ -138,6 +155,32 @@ private fun Profile(name: String) {
                 .fillMaxWidth()
                 .padding(top = 16.dp),
             textAlign = TextAlign.Center
+        )
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 2.dp),
+            color = AttendanceTheme.colors.grayScale.Gray600,
+            style = AttendanceTypography.body2,
+            text = subInfo,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun ColumnScope.SelectTeam(
+    hasTeam: Boolean,
+    onClick: () -> Unit,
+) {
+    if (hasTeam.not()) {
+        YDSButtonSmall(
+            modifier = Modifier
+                .padding(bottom = 28.dp)
+                .align(Alignment.CenterHorizontally),
+            text = stringResource(id = string.member_setting_select_team),
+            state = YdsButtonState.ENABLED,
+            onClick = onClick,
         )
     }
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSettingContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSettingContract.kt
@@ -10,6 +10,8 @@ class MemberSettingContract {
         val showDialog: Boolean = false,
         val generation: Int = 0,
         val memberName: String = "",
+        val memberPosition: String = "",
+        val memberTeam: Team = Team.empty(),
         val isGuest: Boolean = false,
     ) : UiState
 
@@ -27,5 +29,6 @@ class MemberSettingContract {
         object OnLogoutButtonClicked : MemberSettingUiEvent()
         object OnWithdrawButtonClicked : MemberSettingUiEvent()
         object OnPrivacyPolicyButtonClicked : MemberSettingUiEvent()
+        object OnSelectTeamButtonClicked : MemberSettingUiEvent()
     }
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSettingContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSettingContract.kt
@@ -3,6 +3,7 @@ package com.yapp.presentation.ui.member.setting
 import com.yapp.common.base.UiEvent
 import com.yapp.common.base.UiSideEffect
 import com.yapp.common.base.UiState
+import com.yapp.domain.model.Team
 
 class MemberSettingContract {
     data class MemberSettingUiState(
@@ -22,6 +23,7 @@ class MemberSettingContract {
     sealed class MemberSettingUiSideEffect : UiSideEffect {
         object NavigateToLoginScreen : MemberSettingUiSideEffect()
         object NavigateToPrivacyPolicyScreen : MemberSettingUiSideEffect()
+        object NavigateToSelectTeamScreen : MemberSettingUiSideEffect()
         object ShowToast : MemberSettingUiSideEffect()
     }
 

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSettingViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSettingViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.viewModelScope
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.yapp.common.base.BaseViewModel
 import com.yapp.domain.common.KakaoSdkProviderInterface
+import com.yapp.domain.model.Team
+import com.yapp.domain.model.types.TeamType
 import com.yapp.domain.usecases.DeleteMemberInfoUseCase
 import com.yapp.domain.usecases.GetConfigUseCase
 import com.yapp.domain.usecases.GetCurrentMemberInfoUseCase
@@ -34,7 +36,9 @@ class MemberSettingViewModel @Inject constructor(
                     setState {
                         copy(
                             loadState = MemberSettingContract.LoadState.Idle,
-                            memberName = currentMember?.name ?: ""
+                            memberName = currentMember?.name ?: "",
+                            memberPosition = currentMember?.position?.value ?: "",
+                            memberTeam = currentMember?.team ?: Team.empty(),
                         )
                     }
                 }.onFailure {

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSettingViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSettingViewModel.kt
@@ -83,22 +83,22 @@ class MemberSettingViewModel @Inject constructor(
                     require(memberId != null)
 
                     deleteMemberInfoUseCase(memberId).getOrDefault(defaultValue = false).also { isSuccess ->
-                        if (!isSuccess) {
-                            setState { copy(loadState = MemberSettingContract.LoadState.Idle) }
-                            setEffect(MemberSettingContract.MemberSettingUiSideEffect.ShowToast)
-                        }
-
-                        kakaoSdkProvider.withdraw(
-                            onSuccess = {
-                                setState { copy(loadState = MemberSettingContract.LoadState.Idle) }
-                                setEffect(MemberSettingContract.MemberSettingUiSideEffect.NavigateToLoginScreen)
-                            },
-                            onFailed = {
+                            if (!isSuccess) {
                                 setState { copy(loadState = MemberSettingContract.LoadState.Idle) }
                                 setEffect(MemberSettingContract.MemberSettingUiSideEffect.ShowToast)
                             }
-                        )
-                    }
+
+                            kakaoSdkProvider.withdraw(
+                                onSuccess = {
+                                    setState { copy(loadState = MemberSettingContract.LoadState.Idle) }
+                                    setEffect(MemberSettingContract.MemberSettingUiSideEffect.NavigateToLoginScreen)
+                                },
+                                onFailed = {
+                                    setState { copy(loadState = MemberSettingContract.LoadState.Idle) }
+                                    setEffect(MemberSettingContract.MemberSettingUiSideEffect.ShowToast)
+                                }
+                            )
+                        }
                 }
                 .onFailure {
                     setState { copy(loadState = MemberSettingContract.LoadState.Idle) }
@@ -121,6 +121,10 @@ class MemberSettingViewModel @Inject constructor(
 
             is MemberSettingContract.MemberSettingUiEvent.OnPrivacyPolicyButtonClicked -> {
                 setEffect(MemberSettingContract.MemberSettingUiSideEffect.NavigateToPrivacyPolicyScreen)
+            }
+
+            MemberSettingContract.MemberSettingUiEvent.OnSelectTeamButtonClicked -> {
+                setEffect(MemberSettingContract.MemberSettingUiSideEffect.NavigateToSelectTeamScreen)
             }
         }
     }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/position/Position.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/position/Position.kt
@@ -35,7 +35,7 @@ import com.yapp.presentation.ui.member.signup.position.PositionContract.Position
 fun Position(
     viewModel: PositionViewModel = hiltViewModel(),
     onClickBackButton: () -> Unit,
-    navigateToTeamScreen: (String, String) -> Unit
+    navigateToMainScreen: () -> Unit,
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
@@ -43,9 +43,10 @@ fun Position(
     LaunchedEffect(key1 = viewModel.effect) {
         viewModel.effect.collect { effect ->
             when (effect) {
-                is PositionSideEffect.NavigateToTeamScreen -> {
-                    navigateToTeamScreen(effect.name, effect.position.name)
+                is PositionSideEffect.NavigateToMainScreen -> {
+                    navigateToMainScreen()
                 }
+
                 is PositionSideEffect.ShowToast -> {
                     Toast.makeText(context, effect.msg, Toast.LENGTH_LONG).show()
                 }
@@ -92,7 +93,7 @@ fun Position(
                 )
             }
             YDSButtonLarge(
-                text = stringResource(R.string.member_signup_position_next),
+                text = stringResource(R.string.member_signup_team_start_yapp),
                 modifier = Modifier
                     .padding(start = 24.dp, end = 24.dp, bottom = 40.dp)
                     .height(60.dp)
@@ -100,6 +101,7 @@ fun Position(
                 onClick = { viewModel.setEvent(PositionUiEvent.ConfirmPosition) },
                 state = if (uiState.ydsOption.selectedOption != null) YdsButtonState.ENABLED else YdsButtonState.DISABLED
             )
+
         }
     }
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/position/PositionContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/position/PositionContract.kt
@@ -8,12 +8,11 @@ import com.yapp.domain.model.types.PositionType
 
 class PositionContract {
     data class PositionUiState(
-        val ydsOption: YDSOptionState<PositionType> = PositionOptionState()
+        val ydsOption: YDSOptionState<PositionType> = PositionOptionState(),
     ) : UiState
 
     sealed class PositionSideEffect : UiSideEffect {
-        data class NavigateToTeamScreen(val name: String, val position: PositionType) :
-            PositionSideEffect()
+        object NavigateToMainScreen : PositionSideEffect()
 
         data class ShowToast(val msg: String) : PositionSideEffect()
     }
@@ -25,6 +24,6 @@ class PositionContract {
 
     data class PositionOptionState(
         override val items: List<PositionType> = PositionType.values().toList(),
-        override val selectedOption: PositionType? = null
+        override val selectedOption: PositionType? = null,
     ) : YDSOptionState<PositionType>
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/position/PositionViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/position/PositionViewModel.kt
@@ -2,6 +2,7 @@ package com.yapp.presentation.ui.member.signup.position
 
 import androidx.lifecycle.SavedStateHandle
 import com.yapp.common.base.BaseViewModel
+import com.yapp.domain.usecases.SignUpMemberUseCase
 import com.yapp.presentation.ui.member.signup.position.PositionContract.PositionSideEffect
 import com.yapp.presentation.ui.member.signup.position.PositionContract.PositionUiEvent
 import com.yapp.presentation.ui.member.signup.position.PositionContract.PositionUiState
@@ -10,13 +11,14 @@ import javax.inject.Inject
 
 @HiltViewModel
 class PositionViewModel @Inject constructor(
-    private val savedStateHandle: SavedStateHandle
+    private val savedStateHandle: SavedStateHandle,
+    private val signUpMemberUseCase: SignUpMemberUseCase,
 ) : BaseViewModel<PositionUiState, PositionSideEffect, PositionUiEvent>(PositionUiState()) {
     override suspend fun handleEvent(event: PositionUiEvent) {
         when (event) {
             is PositionUiEvent.ChoosePosition -> {
                 if (event.position == null) {
-                    setEffect(PositionSideEffect.ShowToast("적합하지 않은 포지션을 선택하셨습니다.\n다시 선택해주세요."))
+                    setEffect(PositionSideEffect.ShowToast(SELECT_UNSUITABLE_POSITION))
                     return
                 }
 
@@ -24,15 +26,32 @@ class PositionViewModel @Inject constructor(
                     copy(ydsOption = PositionContract.PositionOptionState(selectedOption = event.position))
                 }
             }
+
             is PositionUiEvent.ConfirmPosition -> {
-                val memberName = savedStateHandle.get<String>("name")
-                setEffect(
-                    PositionSideEffect.NavigateToTeamScreen(
-                        memberName!!,
-                        uiState.value.ydsOption.selectedOption!!
-                    )
-                )
+                signUpMember()
             }
         }
+    }
+
+    private suspend fun signUpMember() {
+        val name = savedStateHandle.get<String>("name") ?: throw IllegalStateException(NAME_IS_NULL)
+        val position = currentState.ydsOption.selectedOption ?: throw IllegalStateException(POSITION_IS_NULL)
+        signUpMemberUseCase(
+            params = SignUpMemberUseCase.Params(
+                memberName = name,
+                memberPosition = position
+            )
+        ).onSuccess {
+            setEffect(PositionSideEffect.NavigateToMainScreen)
+        }.onFailure {
+            setEffect(PositionSideEffect.ShowToast(SIGN_UP_FAILED))
+        }
+    }
+
+    companion object {
+        private const val SELECT_UNSUITABLE_POSITION = "적합하지 않은 포지션을 선택하셨습니다.\n다시 선택해주세요."
+        private const val NAME_IS_NULL = "name is null"
+        private const val POSITION_IS_NULL = "position is null"
+        private const val SIGN_UP_FAILED = "회원가입 실패"
     }
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/Team.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/Team.kt
@@ -6,10 +6,22 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -20,20 +32,40 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.accompanist.insets.systemBarsPadding
 import com.yapp.common.theme.AttendanceTheme
 import com.yapp.common.theme.AttendanceTypography
-import com.yapp.common.yds.*
+import com.yapp.common.yds.YDSAppBar
+import com.yapp.common.yds.YDSButtonLarge
+import com.yapp.common.yds.YDSChoiceButton
+import com.yapp.common.yds.YDSEmptyScreen
+import com.yapp.common.yds.YDSOption
+import com.yapp.common.yds.YDSProgressBar
+import com.yapp.common.yds.YdsButtonState
 import com.yapp.presentation.R
-import com.yapp.presentation.ui.member.signup.team.TeamContract.*
-import kotlinx.coroutines.flow.collect
+import com.yapp.presentation.ui.member.setting.MemberSettingContract
+import com.yapp.presentation.ui.member.signup.team.TeamContract.TeamSideEffect
+import com.yapp.presentation.ui.member.signup.team.TeamContract.TeamUiEvent
+import com.yapp.presentation.ui.member.signup.team.TeamContract.TeamUiState
 
 @Composable
 fun Team(
     viewModel: TeamViewModel = hiltViewModel(),
     onClickBackButton: () -> Unit,
-    navigateToMainScreen: () -> Unit
+    navigateToSettingScreen: () -> Unit
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
 
+    LaunchedEffect(key1 = viewModel.effect) {
+        viewModel.effect.collect { effect ->
+            when (effect) {
+                is TeamSideEffect.NavigateToSettingScreen -> {
+                    navigateToSettingScreen()
+                }
+                is TeamSideEffect.ShowToast -> {
+                    Toast.makeText(context, effect.msg, Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+    }
     Scaffold(
         topBar = {
             YDSAppBar(
@@ -45,51 +77,37 @@ fun Team(
             .fillMaxSize()
             .systemBarsPadding()
     ) { contentPadding ->
-        when (uiState.loadState) {
-            TeamUiState.LoadState.Loading -> YDSProgressBar()
-            TeamUiState.LoadState.Error -> YDSEmptyScreen()
-            TeamUiState.LoadState.Idle -> {
-                val onTeamTypeClicked: (String) -> Unit by remember {
-                    mutableStateOf({ teamType ->
-                        viewModel.setEvent(
-                            TeamUiEvent.ChooseTeam(teamType)
-                        )
-                    })
-                }
-
-                val onTeamNumberClicked: (Int) -> Unit by remember {
-                    mutableStateOf({ teamNum ->
-                        viewModel.setEvent(
-                            TeamUiEvent.ChooseTeamNumber(teamNum)
-                        )
-                    })
-                }
-
-                val onConfirmClicked: () -> Unit by remember {
-                    mutableStateOf({ viewModel.setEvent(TeamUiEvent.ConfirmTeam) })
-                }
-
-                TeamScreen(
-                    modifier = Modifier.padding(contentPadding),
-                    uiState = uiState,
-                    onTeamTypeClicked = onTeamTypeClicked,
-                    onTeamNumberClicked = onTeamNumberClicked,
-                    onConfirmClicked = onConfirmClicked,
+        val onTeamTypeClicked: (String) -> Unit by remember {
+            mutableStateOf({ teamType ->
+                viewModel.setEvent(
+                    TeamUiEvent.ChooseTeam(teamType)
                 )
-            }
+            })
         }
 
-        LaunchedEffect(key1 = viewModel.effect) {
-            viewModel.effect.collect { effect ->
-                when (effect) {
-                    is TeamSideEffect.NavigateToMainScreen -> {
-                        navigateToMainScreen()
-                    }
-                    is TeamSideEffect.ShowToast -> {
-                        Toast.makeText(context, effect.msg, Toast.LENGTH_LONG).show()
-                    }
-                }
-            }
+        val onTeamNumberClicked: (Int) -> Unit by remember {
+            mutableStateOf({ teamNum ->
+                viewModel.setEvent(
+                    TeamUiEvent.ChooseTeamNumber(teamNum)
+                )
+            })
+        }
+
+        val onConfirmClicked: () -> Unit by remember {
+            mutableStateOf({ viewModel.setEvent(TeamUiEvent.ConfirmTeam) })
+        }
+
+        TeamScreen(
+            modifier = Modifier.padding(contentPadding),
+            uiState = uiState,
+            onTeamTypeClicked = onTeamTypeClicked,
+            onTeamNumberClicked = onTeamNumberClicked,
+            onConfirmClicked = onConfirmClicked,
+        )
+        if (uiState.loadState== TeamUiState.LoadState.Loading) {
+            YDSProgressBar()
+        } else if (uiState.loadState == TeamUiState.LoadState.Error) {
+            YDSEmptyScreen()
         }
     }
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/Team.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/Team.kt
@@ -104,7 +104,7 @@ fun Team(
             onTeamNumberClicked = onTeamNumberClicked,
             onConfirmClicked = onConfirmClicked,
         )
-        if (uiState.loadState== TeamUiState.LoadState.Loading) {
+        if (uiState.loadState == TeamUiState.LoadState.Loading) {
             YDSProgressBar()
         } else if (uiState.loadState == TeamUiState.LoadState.Error) {
             YDSEmptyScreen()

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/Team.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/Team.kt
@@ -40,7 +40,6 @@ import com.yapp.common.yds.YDSOption
 import com.yapp.common.yds.YDSProgressBar
 import com.yapp.common.yds.YdsButtonState
 import com.yapp.presentation.R
-import com.yapp.presentation.ui.member.setting.MemberSettingContract
 import com.yapp.presentation.ui.member.signup.team.TeamContract.TeamSideEffect
 import com.yapp.presentation.ui.member.signup.team.TeamContract.TeamUiEvent
 import com.yapp.presentation.ui.member.signup.team.TeamContract.TeamUiState

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamContract.kt
@@ -4,6 +4,7 @@ import com.yapp.common.base.UiEvent
 import com.yapp.common.base.UiSideEffect
 import com.yapp.common.base.UiState
 import com.yapp.common.yds.YDSOptionState
+import com.yapp.domain.model.Member
 import com.yapp.domain.model.Team
 import com.yapp.domain.model.types.TeamType
 
@@ -14,6 +15,7 @@ sealed class TeamContract {
         val teamOptionState: YDSOptionState<TeamType> = TeamOptionState(),
         val numberOfSelectedTeamType: Int? = null,
         val teamNumberOptionState: YDSOptionState<Int> = TeamNumberOptionState(),
+        val currentMember: Member? = null,
     ) : UiState {
         enum class LoadState {
             Loading, Idle, Error
@@ -21,7 +23,7 @@ sealed class TeamContract {
     }
 
     sealed class TeamSideEffect : UiSideEffect {
-        object NavigateToMainScreen : TeamSideEffect()
+        object NavigateToSettingScreen : TeamSideEffect()
         data class ShowToast(val msg: String) : TeamSideEffect()
     }
 

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
@@ -75,7 +75,7 @@ class TeamViewModel @Inject constructor(
             setState { copy(loadState = TeamUiState.LoadState.Error) }
             return
         }
-        val member = requireNotNull(currentState.currentMember) { "$FAIL_SELECT_TEAM because member is null" }
+        val member = requireNotNull(currentState.currentMember) { "$SIGN_UP_FAILED because member is null" }
         setMemberUseCase(
             params = member.copy(team = team)
         ).onSuccess {
@@ -87,6 +87,6 @@ class TeamViewModel @Inject constructor(
     }
 
     companion object {
-        private const val FAIL_SELECT_TEAM = "회원가입 실패"
+        private const val SIGN_UP_FAILED = "회원가입 실패"
     }
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/signup/team/TeamViewModel.kt
@@ -1,12 +1,12 @@
 package com.yapp.presentation.ui.member.signup.team
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.yapp.common.base.BaseViewModel
 import com.yapp.domain.model.Team
-import com.yapp.domain.model.types.PositionType
+import com.yapp.domain.model.types.TeamType
+import com.yapp.domain.usecases.GetCurrentMemberInfoUseCase
 import com.yapp.domain.usecases.GetTeamListUseCase
-import com.yapp.domain.usecases.SignUpMemberUseCase
+import com.yapp.domain.usecases.SetMemberUseCase
 import com.yapp.presentation.ui.member.signup.team.TeamContract.TeamSideEffect
 import com.yapp.presentation.ui.member.signup.team.TeamContract.TeamUiEvent
 import com.yapp.presentation.ui.member.signup.team.TeamContract.TeamUiState
@@ -17,8 +17,8 @@ import javax.inject.Inject
 @HiltViewModel
 class TeamViewModel @Inject constructor(
     private val getTeamListUseCase: GetTeamListUseCase,
-    private val signUpMemberUseCase: SignUpMemberUseCase,
-    private val savedStateHandle: SavedStateHandle,
+    private val getCurrentMemberInfoUseCase: GetCurrentMemberInfoUseCase,
+    private val setMemberUseCase: SetMemberUseCase,
 ) : BaseViewModel<TeamUiState, TeamSideEffect, TeamUiEvent>(TeamUiState()) {
 
     init {
@@ -49,44 +49,44 @@ class TeamViewModel @Inject constructor(
                     )
                 }
             }
+
             is TeamUiEvent.ChooseTeamNumber -> {
                 setState {
                     copy(teamNumberOptionState = TeamContract.TeamNumberOptionState(selectedOption = event.teamNum))
                 }
             }
-            is TeamUiEvent.ConfirmTeam -> {
-                if (savedStateHandle.get<String>("name") == null || savedStateHandle.get<String>("position") == null) {
-                    setEffect(TeamSideEffect.ShowToast("회원가입 실패"))
-                    return
-                }
 
-                signUpMember(
-                    memberName = savedStateHandle.get<String>("name")!!,
-                    memberPosition = PositionType.of(savedStateHandle.get<String>("position")!!),
+            is TeamUiEvent.ConfirmTeam -> {
+                setMember(
                     team = Team(
-                        type = uiState.value.teamOptionState.selectedOption!!,
-                        number = uiState.value.teamNumberOptionState.selectedOption!!
+                        type = uiState.value.teamOptionState.selectedOption ?: TeamType.NONE,
+                        number = uiState.value.teamNumberOptionState.selectedOption ?: 0,
                     )
                 )
             }
         }
     }
 
-    private suspend fun signUpMember(
-        memberName: String,
-        memberPosition: PositionType,
-        team: Team,
-    ) {
-        signUpMemberUseCase(
-            params = SignUpMemberUseCase.Params(
-                memberName = memberName,
-                memberPosition = memberPosition,
-                team = team
-            )
-        ).onSuccess {
-            setEffect(TeamSideEffect.NavigateToMainScreen)
+    private suspend fun setMember(team: Team) {
+        setState { copy(loadState = TeamUiState.LoadState.Loading) }
+        getCurrentMemberInfoUseCase().onSuccess {
+            setState { copy(currentMember = it) }
         }.onFailure {
-            setEffect(TeamSideEffect.ShowToast("회원가입 실패"))
+            setState { copy(loadState = TeamUiState.LoadState.Error) }
+            return
         }
+        val member = requireNotNull(currentState.currentMember) { "$FAIL_SELECT_TEAM because member is null" }
+        setMemberUseCase(
+            params = member.copy(team = team)
+        ).onSuccess {
+            setState { copy(loadState = TeamUiState.LoadState.Idle) }
+            setEffect(TeamSideEffect.NavigateToSettingScreen)
+        }.onFailure {
+            setState { copy(loadState = TeamUiState.LoadState.Error) }
+        }
+    }
+
+    companion object {
+        private const val FAIL_SELECT_TEAM = "회원가입 실패"
     }
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="admin_main_see_all_score_text">누적 점수 확인하기</string>
     
     <string name="member_signup_choose_position">속한 직군을\n알려주세요</string>
-    <string name="member_signup_position_next">다음</string>
+    <string name="member_signup_team_start_yapp">YAPP 시작하기</string>
 
     <string name="member_signup_choose_team">소속 팀을\n알려주세요</string>
     <string name="member_signup_choose_team_number">하나만 더 알려주세요</string>
@@ -61,6 +61,7 @@
     <string name="member_setting_withdraw_dialog_negative_button">취소</string>
     <string name="member_setting_withdraw_dialog_positive_button">탈퇴합니다</string>
     <string name="member_setting_error_message">오류가 발생했어요. 다시 시도해주세요.</string>
+    <string name="member_setting_select_team">팀 선택하기</string>
 
     <string name="member_qr_time_inform_text">까지 출석해 주세요.</string>
     <string name="member_qr_late_inform_text">30분까지는 지각, 그 이후는 결석으로 처리돼요.</string>


### PR DESCRIPTION
**Description**
resolve #215 

- 기존 온보딩에서는 팀 결정이 되지 않았지만 온보딩에서 팀을 선택해야만 했습니다. 이를 스킵 할 수 있도록 변경하였습니다.
- 팀을 선택하지 않은 회원의 경우 `설정 - 팀 선택하기 버튼` 에서 팀을 선택할 수 있습니다. 
- TeamType에 팀 없음을 나타내는 `None` 을 추가하였습니다.

**논의해볼 점**
현재는 팀 설정을 잘 못했을 경우, 탈퇴 후 다시 가입해야한다는 단점이 있습니다.
1. 팀을 선택하지 않았을 경우 -> `팀 선택하기`
2. 팀을 선택한 경우 -> `팀 변경하기`

로 항상 버튼을 노출 시켜 변경점을 열어두는 것이 어떨지 제안해봅니다!

**Screen Shots**


https://user-images.githubusercontent.com/70064912/233776803-5bd88944-a6fd-441e-8778-f7a03690b5fc.mp4


**Check List**

- [ ] CI/CD 통과여부
- [ ] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [ ] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [ ] 연관된 이슈를 PR에 연결해주세요.

