### PR TITLE
Fix: YDSOption 컴포넌트의 옵션 개수에 따라 특정 항목이 보이지 않는 문제 수정(FlowRow로 변경)

### DIFF
--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">attendance-android-test</string>
+    <string name="app_name">YAPP(DEV)</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">attendance-android</string>
+    <string name="app_name">YAPP</string>
 </resources>

--- a/common/src/main/java/com/yapp/common/yds/YDSOption.kt
+++ b/common/src/main/java/com/yapp/common/yds/YDSOption.kt
@@ -1,28 +1,31 @@
 package com.yapp.common.yds
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun YDSOption(types: List<String>, selectedType: String?, onTypeClicked: (String) -> Unit) {
-    val rowNum = 2
-    Column {
-        repeat(types.size / rowNum) { row ->
-            Row {
-                repeat(rowNum) { index ->
-                    val type = types[rowNum * row + index]
-                    YDSChoiceButton(
-                        text = type,
-                        modifier = Modifier.padding(end = 12.dp, bottom = 12.dp),
-                        state = if (selectedType == type) YdsButtonState.ENABLED else YdsButtonState.DISABLED,
-                        onClick = { onTypeClicked(type) }
-                    )
-                }
-            }
+fun YDSOption(
+    modifier: Modifier = Modifier,
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.spacedBy(12.dp),
+    types: List<String>,
+    selectedType: String?,
+    onTypeClicked: (String) -> Unit
+) {
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = horizontalArrangement,
+    ) {
+        repeat(types.size) { index ->
+            val type = types[index]
+            YDSChoiceButton(
+                text = type,
+                modifier = Modifier.padding(bottom = 12.dp),
+                state = if (selectedType == type) YdsButtonState.ENABLED else YdsButtonState.DISABLED,
+                onClick = { onTypeClicked(type) }
+            )
         }
     }
 }


### PR DESCRIPTION
**Description**
YDSOption 컴포넌트의 옵션 개수에 따라 특정 항목이 보이지 않는 문제 수정(FlowRow로 변경) #322 
앱 이름 변경(attendance-android -> YAPP)


**Screen Shots**

| 변경 전 | 변경 후 |
| ----------- | ----------- |
| <img width="315" alt="스크린샷 2023-11-09 오후 11 18 32" src="https://github.com/YAPP-admin/attendance-android/assets/42907876/c87cd72c-a8a1-4fcf-9737-77d94ac4cbbd"> | <img width="317" alt="스크린샷 2023-11-09 오후 11 17 33" src="https://github.com/YAPP-admin/attendance-android/assets/42907876/e2695dae-8cbc-4f10-adba-f296b4a953c9"> |



**Check List**

- [x] CI/CD 통과여부
- [ ] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [ ] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [x] 연관된 이슈를 PR에 연결해주세요.

