### PR TITLE
Fix : 어드민 멤버제거 기능에서 잘못 사용되는 UseCase 제거

### DIFF
--- a/domain/src/main/java/com/yapp/domain/usecases/WithdrawMemberInfoUseCase.kt
+++ b/domain/src/main/java/com/yapp/domain/usecases/WithdrawMemberInfoUseCase.kt
@@ -4,9 +4,14 @@ import com.yapp.domain.repository.LocalRepository
 import com.yapp.domain.repository.MemberRepository
 import javax.inject.Inject
 
-class DeleteMemberInfoUseCase @Inject constructor(
+/**
+ * 멤버 **스스로** 회원 탈퇴 기능을 사용할때의 UseCase
+ *
+ * 로컬에 저장된 Kakao MemberId를 제거 -> FireStore에 존재하는 데이터를 제거합니다.
+ */
+class WithdrawMemberInfoUseCase @Inject constructor(
     private val localRepository: LocalRepository,
-    private val memberRepository: MemberRepository,
+    private val memberRepository: MemberRepository
 ) {
 
     suspend operator fun invoke(memberId: Long): Result<Boolean> {

--- a/presentation/src/main/java/com/yapp/presentation/ui/admin/management/Management.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/admin/management/Management.kt
@@ -2,6 +2,7 @@ package com.yapp.presentation.ui.admin.management
 
 import FoldableHeaderItemState
 import android.annotation.SuppressLint
+import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -33,6 +34,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -72,6 +74,7 @@ fun AttendanceManagement(
     onBackButtonClicked: (() -> Unit)? = null
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
 
     when (uiState.loadState) {
         Loading -> YDSProgressBar()
@@ -91,6 +94,9 @@ fun AttendanceManagement(
     LaunchedEffect(key1 = viewModel.effect, key2 = lifeCycleOwner) {
         lifeCycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             viewModel.effect.collect { effect ->
+                if (effect is ManagementContract.ManagementSideEffect.ShowToast) {
+                    Toast.makeText(context, effect.description, Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/yapp/presentation/ui/admin/management/ManagementContract.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/admin/management/ManagementContract.kt
@@ -40,5 +40,7 @@ class ManagementContract {
         class OnTeamTypeHeaderItemClicked(val teamName: String, val teamNumber: Int) : ManagementEvent()
     }
 
-    sealed class ManagementSideEffect : UiSideEffect
+    sealed class ManagementSideEffect : UiSideEffect {
+        class ShowToast(val description: String) : ManagementSideEffect()
+    }
 }

--- a/presentation/src/main/java/com/yapp/presentation/ui/admin/management/ManagementViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/admin/management/ManagementViewModel.kt
@@ -4,11 +4,12 @@ import FoldableHeaderItemState
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.yapp.common.base.BaseViewModel
+import com.yapp.domain.common.KakaoSdkProviderInterface
 import com.yapp.domain.model.Attendance
 import com.yapp.domain.model.Member
 import com.yapp.domain.model.Team
 import com.yapp.domain.model.types.PositionType
-import com.yapp.domain.usecases.DeleteMemberInfoUseCase
+import com.yapp.domain.repository.MemberRepository
 import com.yapp.domain.usecases.GetAllMemberUseCase
 import com.yapp.domain.usecases.SetMemberAttendanceUseCase
 import com.yapp.presentation.ui.admin.AdminConstants.KEY_SESSION_ID
@@ -43,7 +44,7 @@ class ManagementViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     getAllMemberUseCase: GetAllMemberUseCase,
     private val setMemberAttendanceUseCase: SetMemberAttendanceUseCase,
-    private val deleteMemberInfoUseCase: DeleteMemberInfoUseCase
+    private val memberRepository: MemberRepository
 ) : BaseViewModel<ManagementState, ManagementSideEffect, ManagementEvent>(ManagementState()) {
 
     companion object {
@@ -103,7 +104,13 @@ class ManagementViewModel @Inject constructor(
             }
 
             is ManagementEvent.OnDeleteMemberClicked -> {
-                deleteMemberInfoUseCase(event.memberId)
+                memberRepository.deleteMember(event.memberId).also { result ->
+                    if (result.isSuccess) {
+                        setEffect(ManagementSideEffect.ShowToast("멤버를 삭제하는데 실패했습니다"))
+                    } else {
+                        setEffect(ManagementSideEffect.ShowToast("멤버를 성공적으로 제거했습니다"))
+                    }
+                }
             }
 
             is ManagementEvent.OnPositionTypeHeaderItemClicked -> {

--- a/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSettingViewModel.kt
+++ b/presentation/src/main/java/com/yapp/presentation/ui/member/setting/MemberSettingViewModel.kt
@@ -5,8 +5,7 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.yapp.common.base.BaseViewModel
 import com.yapp.domain.common.KakaoSdkProviderInterface
 import com.yapp.domain.model.Team
-import com.yapp.domain.model.types.TeamType
-import com.yapp.domain.usecases.DeleteMemberInfoUseCase
+import com.yapp.domain.usecases.WithdrawMemberInfoUseCase
 import com.yapp.domain.usecases.GetConfigUseCase
 import com.yapp.domain.usecases.GetCurrentMemberInfoUseCase
 import com.yapp.domain.usecases.GetMemberIdUseCase
@@ -20,7 +19,7 @@ class MemberSettingViewModel @Inject constructor(
     private val kakaoSdkProvider: KakaoSdkProviderInterface,
     private val getMemberIdUseCase: GetMemberIdUseCase,
     private val getCurrentMemberInfoUseCase: GetCurrentMemberInfoUseCase,
-    private val deleteMemberInfoUseCase: DeleteMemberInfoUseCase,
+    private val withdrawMemberInfoUseCase: WithdrawMemberInfoUseCase,
     private val getConfigUseCase: GetConfigUseCase,
     private val shouldShowGuestButtonUseCase: ShouldShowGuestButtonUseCase,
 ) :
@@ -82,7 +81,7 @@ class MemberSettingViewModel @Inject constructor(
                 .onSuccess { memberId ->
                     require(memberId != null)
 
-                    deleteMemberInfoUseCase(memberId).getOrDefault(defaultValue = false).also { isSuccess ->
+                    withdrawMemberInfoUseCase(memberId).getOrDefault(defaultValue = false).also { isSuccess ->
                             if (!isSuccess) {
                                 setState { copy(loadState = MemberSettingContract.LoadState.Idle) }
                                 setEffect(MemberSettingContract.MemberSettingUiSideEffect.ShowToast)
@@ -141,7 +140,7 @@ class MemberSettingViewModel @Inject constructor(
             getMemberIdUseCase()
                 .onSuccess { memberId ->
                     require(memberId != null)
-                    deleteMemberInfoUseCase(memberId).getOrDefault(false).also { isSuccess ->
+                    withdrawMemberInfoUseCase(memberId).getOrDefault(false).also { isSuccess ->
                         if (!isSuccess) {
                             setState { copy(loadState = MemberSettingContract.LoadState.Idle) }
                             setEffect(MemberSettingContract.MemberSettingUiSideEffect.ShowToast)


### PR DESCRIPTION
**Description**
- DeleteMemberUseCase -> WithdrawMemberUseCase 로 명칭 변경
- WithdrawMemberUseCase는 회원 스스로가 탈퇴할때를 가정한 UseCase로 Local의 Memeber Id를 함께 제거하는 로직이 있음

- 때문에 이를 사용하지 않고 MemberRepository의 deleteMember 메서드를 사용하여 DB에서만 제거
   - [카카오 로그인 API]는 회원 스스로가 탈퇴하는것만 지원하기 때문
      (어드민이  [카카오 로그인 API] 에서 탈퇴시키는것은 불가)

- 멤버 제거 성공 / 실패시 Toast를 사용하여 알림 추가


**Screen Shots**

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|             |             |



**Check List**

- [ ] CI/CD 통과여부
- [ ] Develop Mege 시 Squash and Merge 형태로 넣어주세요!
- [ ] 1Approve 이상 Merge
- [ ] Unit Test 작성
- [ ] 연관된 이슈를 PR에 연결해주세요.

